### PR TITLE
fix line breaks

### DIFF
--- a/README
+++ b/README
@@ -34,11 +34,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     Ronald MacDonald <ronald@rmacd.com>
 
 * Special Thanks:
-	John David Stone- For allowing this web based plans system to be created and run 
-		at Grinnell. For putting up with some of the hassles while this project was 
-		evolving. For knowing how to run a network. For being a true mentor.
+	John David Stone- For allowing this web based plans system to be 
+		created and run at Grinnell. For putting up with some of the 
+		hassles while this project was evolving. For knowing how to 
+		run a network. For being a true mentor.
 
 	Rachel Heck- For the original Grinnell Web Based Plans.
 
-	Vax-Gods- The original gods who maintained the cultural phenomena of plans 
-		at Grinnell.        
+	Vax-Gods- The original gods who maintained the cultural phenomena of 
+		plans at Grinnell.        


### PR DESCRIPTION
Formatting was busted at the bottom. This patch adjusts all lines to break before column 80.
