### PR TITLE
Use composer to manage external libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 Configuration.php
+composer.phar

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/aws"]
-	path = lib/aws
-	url = https://github.com/amazonwebservices/aws-sdk-for-php

--- a/Configuration.php.tmpl
+++ b/Configuration.php.tmpl
@@ -34,10 +34,10 @@ define('MAILER_ADDRESS', "noreply@grinnellplans.com");
 define('USE_NATIVE_MAIL', true);	//~(use AWS mail service if false)
 
 //AWS credentials - needed if aws mail is enabled
-define('AWS_KEY', '');
-define('AWS_SECRET_KEY', '');
-
-
+if (!USE_NATIVE_MAIL) {
+    define('AWS_KEY', '');
+    define('AWS_SECRET_KEY', '');
+}
 
 // Use this if you wish to override the auto-detected environment type.
 // Options are 'development', 'production', or 'testing'

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 define('__ROOT__', dirname(__FILE__));
+// Composer setup 
+require_once(__DIR__.'/vendor/autoload.php');
 require_once ('Configuration.php');
 set_include_path(get_include_path() . ':' . __ROOT__ . ':' . __ROOT__ . '/inc');
 putenv('TZ=' . TZ);

--- a/composer-dl.sh
+++ b/composer-dl.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "grinnellplans/grinnellplans-php",
+    "description": "GrinnellPlans, a social networking site",
+    "type": "project",
+    "require": {
+        "amazonwebservices/aws-sdk-for-php": "^1.6"
+    },
+    "license": "gpl3"
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,72 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2bdea54c8a7ac1015af8dd94525d35b5",
+    "packages": [
+        {
+            "name": "amazonwebservices/aws-sdk-for-php",
+            "version": "1.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amazonwebservices/aws-sdk-for-php.git",
+                "reference": "0507424b05bd191f043375b787640bd1eb4f692b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amazonwebservices/aws-sdk-for-php/zipball/0507424b05bd191f043375b787640bd1eb4f692b",
+                "reference": "0507424b05bd191f043375b787640bd1eb4f692b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "You should consider upgrading to version 2 of the AWS SDK for PHP"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "authentication/",
+                    "extensions/",
+                    "lib/",
+                    "services/",
+                    "utilities/",
+                    "sdk.class.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP",
+            "homepage": "http://aws.amazon.com/sdkforphp/",
+            "keywords": [
+                "amazon",
+                "aws",
+                "dynamodb",
+                "ec2",
+                "s3",
+                "sdk"
+            ],
+            "abandoned": "aws/aws-sdk-php",
+            "time": "2014-10-15T20:05:19+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/functions-email.php
+++ b/functions-email.php
@@ -1,9 +1,12 @@
 <?php
 require_once ('Plans.php');
-require_once ('lib/aws/sdk.class.php');
 
-if (defined('AWS_KEY')) {
-    CFCredentials::set(array('default'=>array('key'=>AWS_KEY,'secret'=>AWS_SECRET_KEY)));
+if (USE_NATIVE_MAIL) {
+    if (defined('AWS_KEY')) {
+        CFCredentials::set(array('default'=>array('key'=>AWS_KEY,'secret'=>AWS_SECRET_KEY)));
+    } else {
+        CFCredentials::set(array('default'=>array('default_cache_config'=>'/tmp')));
+    }
 }
 
 function send_mail($to, $subject, $text, $from = MAILER_ADDRESS, $reply_to = ADMIN_ADDRESS) {


### PR DESCRIPTION
Instead of pulling in the AWS sdk with a Git submodule, use Composer to install it. 