### PR TITLE
Use new PHP password hashing API

### DIFF
--- a/changeemail.php
+++ b/changeemail.php
@@ -24,7 +24,7 @@ if (!User::logged_in()) {
     if ($changed == 'email') {
         $newemail = $_POST['email'];
         $user = User::get();
-        if (isset($_POST['password']) && ($user->password == crypt($_POST['password'],$user->password))) {
+        if (isset($_POST['password']) && password_verify($_POST['password'],$user->password)) {
 	    if ($newemail == "" || filter_var($newemail, FILTER_VALIDATE_EMAIL) !== false) {
             if (User::setEmail($newemail)) {
 	            $success = new InfoText("Your email address has been updated!",'Success');

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "GrinnellPlans, a social networking site",
     "type": "project",
     "require": {
-        "amazonwebservices/aws-sdk-for-php": "^1.6"
+        "amazonwebservices/aws-sdk-for-php": "^1.6",
+        "ircmaxell/password-compat": "^1.0"
     },
     "license": "gpl3"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bdea54c8a7ac1015af8dd94525d35b5",
+    "content-hash": "76819b2d2b8862be0bb46078c4eb635e",
     "packages": [
         {
             "name": "amazonwebservices/aws-sdk-for-php",
@@ -59,6 +59,48 @@
             ],
             "abandoned": "aws/aws-sdk-php",
             "time": "2014-10-15T20:05:19+00:00"
+        },
+        {
+            "name": "ircmaxell/password-compat",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/password_compat.git",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/password.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@php.net",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
+            "homepage": "https://github.com/ircmaxell/password_compat",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "time": "2014-11-20T16:49:30+00:00"
         }
     ],
     "packages-dev": [],

--- a/inc/User.php
+++ b/inc/User.php
@@ -20,8 +20,15 @@ class User {
     public static function checkPassword($username, $password) {
 	$user = User::get($username);
         if ($user == false) return false;
-        $newpass = crypt($password, $user->password);
-        return ($newpass != '' && $newpass == $user->password);
+        if (password_verify($password,$user->password)) {
+            if (password_needs_rehash($user->password, PASSWORD_DEFAULT)) {
+                $user->password = User::hashPassword($password);
+                $user->save();
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
     /**
      * @return boolean true if password updated successfully
@@ -29,7 +36,7 @@ class User {
     public static function changePassword($username, $newpassword, $oldpassword = null) {
         $user = User::get($username);
         if ($user->username != $username) return false;
-        if (($oldpassword !== null) && ($user->password != crypt($oldpassword,$user->password)))
+        if (($oldpassword !== null) && (!password_verify($oldpassword,$user->password)))
             return false;
         if (strlen($newpassword) < 4) return false;
         $user->password = User::hashPassword($newpassword);
@@ -110,7 +117,7 @@ EOT;
      * @return string a one-way hash of the password, suitable for storage
      */
     public static function hashPassword($password) {
-        return crypt($password);
+        return password_hash($password,PASSWORD_DEFAULT);
     }
 
     public static function get($username = null) {


### PR DESCRIPTION
Currently, Plans uses the `crypt()` function to hash user passwords, which has the advantage of being portable but uses a somewhat weak MD5-based hash by default. PHP 5.6+/7+ includes a new API for hashing passwords that currently uses the bcrypt algorithm. It is backwards compatible with existing password hashes and will upgrade them to bcrypt as users log in. 

There is one user-facing change here that will need to be called out: Users who have not changed their passwords in more than approximately five years will have passwords stored using an even more ancient DES-based algorithm, which only cares about the first eight characters of passwords. Once this PR is pushed to production, the first time users with really old passwords log in, we will remember the full password they typed. Future logins will require the same password to be typed in identically. Some users may be expecting the previous behavior, and may be surprised by the change. A MOTD will be posted calling out this change.

Additionally, this PR adds a polyfill library for the new password hashing algorithm, so Plans will maintain backwards compatibility to currently-supported PHP versions. (I think we're able to run on PHP 5.2+ currently?)