### PR TITLE
unbreak login api call

### DIFF
--- a/api/1/index.php
+++ b/api/1/index.php
@@ -200,21 +200,6 @@ function doLoginTask() {
         $response['message'] = "Invalid username or password.";
     } else {
         $response['success'] = true;
-        $geoip = Net_GeoIP::getInstance(GEO_DATABASE);
-        try {
-            $location = $geoip->lookupLocation($_SERVER['REMOTE_ADDR']);
-            $user->Location->country = $location->countryCode;
-            $user->Location->region = $location->region;
-            $user->Location->city = $location->city;
-            $user->Location->latitude = $location->latitude;
-            $user->Location->longitude = $location->longitude;
-            $user->Location->save();
-        }
-        catch(Exception $e) {
-            // Ignore
-            
-        }
-        $user->save();
         $response['autofingerList'] = getAutofingerList();
     }
     return $response;


### PR DESCRIPTION
The login API also tries to update the user's geolocation. I missed this when I removed the rest of the GeoIP stuff, which meant that the API php file tried to import a now-deleted class. Oops!

The removed `$user->save()` call has always been superfluous - `User::login()` saves before returning, and nothing in between that point and this one mutates the `$user` object. 