### PR TITLE
Usernames must not be the same as passwords

### DIFF
--- a/changepassword.php
+++ b/changepassword.php
@@ -24,7 +24,7 @@ if (!User::logged_in()) {
     }
     if ($changed == 'pass') {
         if ($_POST['mypassword'] == $_POST['mypassword2']) {
-            if (strlen($_POST['mypassword']) > 3) {
+            if (strlen($_POST['mypassword']) > 3 && ($_POST['mypassword'] !== User::get()->username) ) {
                 if (User::changePassword(User::get()->username,$_POST['mypassword'],$_POST['oldpassword'])) {
                     $success = new InfoText("Your password has been changed!", 'Success');
                     $thispage->append($success);
@@ -33,7 +33,7 @@ if (!User::logged_in()) {
                     $thispage->append($denied);
                 }
             } else {
-                $denied = new AlertText('Could not change password. Your password must be 4 or more characters.', 'Bad Password', true);
+                $denied = new AlertText('Could not change password. Your password must be 4 or more characters and must not be the same as your username.', 'Bad Password', true);
                 $thispage->append($denied);
             }
         } else {

--- a/inc/User.php
+++ b/inc/User.php
@@ -40,6 +40,7 @@ class User {
         if (($oldpassword !== null) && (!password_verify($oldpassword,$user->password)))
             return false;
         if (strlen($newpassword) < 4) return false;
+	if ($newpassword === $user->username) return false;
         $user->password = User::hashPassword($newpassword);
         $user->save();
         return true;
@@ -53,6 +54,7 @@ class User {
         if (!$validhash) return false;
         if ($expires < time()) return false;
         if ($hash != $validhash) return false;
+	if ($password === $user->username) return false;
         if ($user === false || $user->username != $username) return false;
         if ($password === null) {
                 //If we don't get a password, generate an 8-character one for the user, using the Base64 character set (0-9A-Za-z+-.

--- a/inc/User.php
+++ b/inc/User.php
@@ -34,13 +34,13 @@ class User {
     /**
      * @return boolean true if password updated successfully
      */
-    public static function changePassword($username, $newpassword, $oldpassword = null) {
+    public static function changePassword($username, $newpassword, $oldpassword = null, $override_requirements = false) {
         $user = User::get($username);
         if ($user->username != $username) return false;
         if (($oldpassword !== null) && (!password_verify($oldpassword,$user->password)))
             return false;
-        if (strlen($newpassword) < 4) return false;
-	if ($newpassword === $user->username) return false;
+        if (!$override_requirements && strlen($newpassword) < 4) return false;
+	if (!$override_requirements && $newpassword === $user->username) return false;
         $user->password = User::hashPassword($newpassword);
         $user->save();
         return true;

--- a/kommand/changepassword.php
+++ b/kommand/changepassword.php
@@ -1,6 +1,5 @@
 <?php
 require_once ("../Plans.php");
-$subject_name = $_POST['username'];
 require ("auth.php");
 ?>
 
@@ -9,25 +8,19 @@ require ("auth.php");
 <?php
 require ("dbfunctions.php");
 $dbh = db_connect();
-if ($subject_name) {
-    if (isvaliduser($dbh, $subject_name)) {
-        $info = get_items($dbh, "userid,email", "accounts", "username", $subject_name);
-        $subject_id = $info[0][0];
-        $email = $info[0][1];
-        if (!$password) {
-            srand(time());
-            $password = rand(0, 999999);
-        }
-        User::changePassword($subject_name,$password);
+if (isset($_POST['username'])) {
+    $user = User::get($_POST['username']);
+    if ($user) {
+        User::changePassword($user->username,$_POST['password'],null,true);
         echo "<form action=\"email.php\" method=\"POST\">";
-        echo "<input type=\"hidden\" name=\"email\" value=\"" . $email . "\">";
-        echo "<input type=\"hidden\" name=\"username\" value=\"" . $subject_name . "\">";
-        echo "<input type=\"hidden\" name=\"password\" value=\"" . $password . "\">";
+        echo "<input type=\"hidden\" name=\"email\" value=\"" . $user->email . "\">";
+        echo "<input type=\"hidden\" name=\"username\" value=\"" . $user->username . "\">";
+        echo "<input type=\"hidden\" name=\"password\" value=\"" . $_POST['password'] . "\">";
         echo "<input type=\"hidden\" name=\"whatoperation\" 
 value=\"changepassword\">";
         echo "<input type=\"submit\" value=\"Send Email\"></form>";
     } else {
-        echo $subject_name . "does not exist.";
+        echo $_POST['username'] . "does not exist.";
     }
 } //if a username
 { //if no username

--- a/passwordreset.php
+++ b/passwordreset.php
@@ -28,7 +28,7 @@ if (User::logged_in()) {
 } else if (isset($_REQUEST['u']) && isset($_REQUEST['e']) && isset($_REQUEST['h'])) {
     if ((User::getPasswordResetHash($_REQUEST['u'],$_REQUEST['e']) == $_REQUEST['h']) && ($_REQUEST['e'] > time())) {
         if (isset($_POST['password1']) && isset($_POST['password2'])) {
-            if (($_POST['password1'] == $_POST['password2']) && (strlen($_POST['password1']) >= 4)) {
+            if (($_POST['password1'] == $_POST['password2']) && (strlen($_POST['password1']) >= 4) && $_POST['u'] !== $_POST['password1']) {
                 if (User::resetPassword($_REQUEST['u'],$_REQUEST['e'],$_REQUEST['h'],$_POST['password1'])) {
                     $msg = new InfoText('Your password has been changed. Please <a href="/index.php">log in!</a>!','Reset successful');
                     $page->append($msg);
@@ -45,7 +45,7 @@ if (User::logged_in()) {
                 $page->append(reset_step2());
             } else {
                 //Length requirement not met
-                $msg = new AlertText("Error: Passwords must be at least four characters long.","Password too short");
+                $msg = new AlertText("Error: Passwords must be at least four characters long and must not be the same as your username.","Password too short or same as username");
                 $page->append($msg);
                 $page->append(reset_step2());
             }


### PR DESCRIPTION
I'm proposing adding a new requirement for passwords: that they cannot be the same as usernames. There have been a lot of group accounts out there that have been made into de-facto public plans by their maintainers by setting their usernames equal to their passwords, but have not been flagged as write-only. The existence of these accounts allows a malicious user to bypass the blocking feature.

Additionally, several users have set their passwords equal to their usernames (I have no idea why). We would like to discourage this as well.

I'm proposing restricting users from setting their password to be the same as their username.

Considered but not done: 
1. Adding `strtolower()` calls around the username and password to block all case variations.
2. Refactoring the password requirements checker into a method in /inc/User.php