### PR TITLE
Allow admins to change write-only bit from kommand

### DIFF
--- a/kommand/changewriteonly.php
+++ b/kommand/changewriteonly.php
@@ -1,36 +1,37 @@
 <?php
 require_once ('../Plans.php');
 require_once('auth.php');
-require_once('../functions-email.php');
 ?>
 <html>
 <body>
-<form method="POST" action="changeemail.php">
+<form method="POST" action="changewriteonly.php">
 <?php
-if (isset($_REQUEST['username']) && isset($_POST['email'])) {
-$oldemail = User::get($_REQUEST['username'])->email;
-if (User::setEmail($_POST['email'],$_REQUEST['username'])) {
-$audit = User::get()->username." changed ".$_REQUEST['username']."'s email address.\n";
-$audit.= "Former email address: ".$oldemail." \n";
-$audit.= "New email address: ".$_REQUEST['email']." \n";
-send_mail(ADMIN_ADDRESS,"Plans audit event: email for ".$_REQUEST['username']." changed", $audit);
-echo 'Email address updated.';
+if (isset($_REQUEST['username']) && isset($_POST['write-only'])) {
+$user = User::get($_REQUEST['username']);
+if ($_POST['write-only'] === "true") {
+$user->Perms->status = 'write-only';
 } else {
-echo 'Error updating email address. <a href="changeemail.php?username="'.htmlentities($_REQUEST['username']).'">Try again?</a>';
-}//if update succeeded
-} elseif (isset($_REQUEST['username']) && (($user = User::get($_REQUEST['username'])) !== false)) { ?>
-Username : <?php echo $user->username; ?>
-<input type="hidden" name="username" value="<?php echo htmlspecialchars($user->username); ?>" /><br />
-Email Address : <input type="email" name="email" value="<?php echo htmlspecialchars($user->email); ?>" /> <br />
-<input type="submit" value="Change Email" />
+$user->Perms->status = '';
+}
+$user->save();
+echo 'Write-only status updated.';
+} elseif (isset($_REQUEST['username']) && (($user = User::get($_REQUEST['username'])) !== false)) {
+$write_only = ($user->Perms->status == 'write-only');
+ ?>
+<table><tr><td>Username: </td><td><?php echo $user->username; ?>
+<input type="hidden" name="username" value="<?php echo htmlspecialchars($user->username); ?>" /></td></tr>
+<tr><td rowspan="2">Write-only: </td>
+<td><label><input type="radio" name="write-only" value="true" <?php echo $write_only?"checked ":""?>/>yes</label></td></tr>
+<tr><td><label><input type="radio" name="write-only" value="false" <?php echo $write_only?"":"checked " ?>/>no</label></td></tr>
+<tr><td /><td><input type="submit" value="Update account" /></td></tr>
+</table>
 <?php } else { /*!isset(username) */ 
 if (isset($_REQUEST['username'])) echo 'Invalid or nonexistent username.<br />';
 ?>
-Username : <input type="text" name="username" value="<?php if (isset($_REQUEST['username'])) echo htmlspecialchars($_REQUEST['username']); ?>" /> 
+Username: <input type="text" name="username" value="<?php if (isset($_REQUEST['username'])) echo htmlspecialchars($_REQUEST['username']); ?>" /> 
 <input type="submit" value="Look Up" />
 <?php } /* !isset(username) */ ?>
 </form>
-<br />Usage of this tool will send audit emails to other administrators, and will email the user's old and new addresses.
 <br /><a href="index.php">Return to Kommand</a>
 </body>
 </html>

--- a/kommand/changewriteonly.php
+++ b/kommand/changewriteonly.php
@@ -1,0 +1,36 @@
+<?php
+require_once ('../Plans.php');
+require_once('auth.php');
+require_once('../functions-email.php');
+?>
+<html>
+<body>
+<form method="POST" action="changeemail.php">
+<?php
+if (isset($_REQUEST['username']) && isset($_POST['email'])) {
+$oldemail = User::get($_REQUEST['username'])->email;
+if (User::setEmail($_POST['email'],$_REQUEST['username'])) {
+$audit = User::get()->username." changed ".$_REQUEST['username']."'s email address.\n";
+$audit.= "Former email address: ".$oldemail." \n";
+$audit.= "New email address: ".$_REQUEST['email']." \n";
+send_mail(ADMIN_ADDRESS,"Plans audit event: email for ".$_REQUEST['username']." changed", $audit);
+echo 'Email address updated.';
+} else {
+echo 'Error updating email address. <a href="changeemail.php?username="'.htmlentities($_REQUEST['username']).'">Try again?</a>';
+}//if update succeeded
+} elseif (isset($_REQUEST['username']) && (($user = User::get($_REQUEST['username'])) !== false)) { ?>
+Username : <?php echo $user->username; ?>
+<input type="hidden" name="username" value="<?php echo htmlspecialchars($user->username); ?>" /><br />
+Email Address : <input type="email" name="email" value="<?php echo htmlspecialchars($user->email); ?>" /> <br />
+<input type="submit" value="Change Email" />
+<?php } else { /*!isset(username) */ 
+if (isset($_REQUEST['username'])) echo 'Invalid or nonexistent username.<br />';
+?>
+Username : <input type="text" name="username" value="<?php if (isset($_REQUEST['username'])) echo htmlspecialchars($_REQUEST['username']); ?>" /> 
+<input type="submit" value="Look Up" />
+<?php } /* !isset(username) */ ?>
+</form>
+<br />Usage of this tool will send audit emails to other administrators, and will email the user's old and new addresses.
+<br /><a href="index.php">Return to Kommand</a>
+</body>
+</html>

--- a/kommand/index.php
+++ b/kommand/index.php
@@ -11,6 +11,7 @@ if (User::is_admin()) {
 <a href="deleteuser.php">Delete User</a><br>
 <a href="changeemail.php">Change Email</a><br>
 <a href="changepassword.php">Change Password</a><br>
+<a href="changewriteonly.php">Change Write-only</a><br>
 <a href="changemotd.php">Change MOTD</a><br />
 <a href="secrets.php">Manage Secrets</a><br />
 <a href="manage-donations.php">Manage Donations</a><br />
@@ -20,32 +21,11 @@ if (User::is_admin()) {
 <a href="update-frequency.cgi">Update Frequency</a><br />
 <a href="swap-password.php">Switch a User's password with that of [test].</a><br />
 <a href="style-stats.php">Display Prefs Statistics</a><br/>
-<pre>
-<?php
-    show_penetration();
-?>
-</pre>
-<?php
-} else if ($wrong_passwrod) {
-?>
-<html><body>Wrong password.<br><form action="index.php" method="POST">
-<input type="text" name="username"><Br>
-<input type="password" name="password"><br>
-<input type="submit" value="Kommand">
-</form>
 <?php
 } else {
 ?>
-<html><body><form action="index.php" method="POST">
-<input type="text" name="username"><Br>
-<input type="password" name="password"><br>
-<input type="submit" value="Kommand">
-</form>
+Usage of these tools is restricted to administrators.
 <?php
-}
-function show_penetration() {
-    //	system('/title/grinnellplans.com/class-year-penetration/run-counts.sh');
-    
 }
 ?>
 </body>


### PR DESCRIPTION
Previously, viewing an account's write-only status required logging into the account and setting an account to write-only required running a raw SQL UPDATE. Now, any admin can see an account's write-only status and set accounts to write-only from Kommand.