### PR TITLE
add meta viewport tag to tableless interface, login screen, and a few more pages for better mobile compat

### DIFF
--- a/documents/faq.html
+++ b/documents/faq.html
@@ -3,396 +3,1226 @@
 <html>
   <head>
     <title>Frequently Asked Questions About Plans v2</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
-<body>
+  <body>
 
-<center><h1>Plans v2 FAQ</h1></center>
-<ul>
-<li><a href="#history">Plan history:</a>
-  <ul>
-  <li><a href="#plans">Where did plans come from?</a>
-  <li><a href="#classproj">Is the program a class project, or a commercial
-product or what?</a>
-</ul>
-<li><a href="#problems">Problems with Plans</a>
+    <center><h1>Plans v2 FAQ</h1></center>
+    <ul>
+      <li><a href="#history">Plan history:</a>
+        <ul>
+          <li><a href="#plans">Where did plans come from?</a>
+            <li><a href="#classproj">Is the program a class project, or a
+                commercial
+                product or what?</a>
+            </ul>
+            <li><a href="#problems">Problems with Plans</a>
 
-<ul>
-  <li><a href="#bug">What should I do if I find a bug in the program, have
-a comment, question or criticism, or if the program simply isn't
-working?</a>
-  <li><a href="#cookies">I can log in, but then when I click on anything 
-it tells me that I am a guest, what should I do?</a>
-  <li><a href="#cvs">Where can I get a copy of the source code for 
-Plans?</a>
+              <ul>
+                <li><a href="#bug">What should I do if I find a bug in the
+                    program, have
+                    a comment, question or criticism, or if the program simply
+                    isn't
+                    working?</a>
+                  <li><a href="#cookies">I can log in, but then when I click on
+                      anything
+                      it tells me that I am a guest, what should I do?</a>
+                    <li><a href="#cvs">Where can I get a copy of the source code
+                        for
+                        Plans?</a>
 
-</ul>
+                    </ul>
 
-<li><a href="#newplan">Getting a new plan:</a>
-  <ul>
-  <li><a href="#criteria">What criteria do I have to meet to be given a
-plan?</a>
-  <li><a href="#groups">Can campus groups have plans?</a>
-  <li><a href="#admin">Can administrators/faculty have plans?</a>
-  <li><a href="#request">What do I do/Who do I contact if I want a new
-plan?</a>
-  </ul>
-<li><a href="#features">About plan features:</a>
-  <ul>
-  <li><a href="#links">How do I put in a link to another person's
-plan?</a>
-  <li><a href="#boardlinks">How do I put in a link to a message on the 
-Notes board?</a>
-  <li><a href="#outside">How do I put in a link to a webpage outside of 
-Plans?</a>
-  <li><a href="#carlist">Is there a way to see who has you on their
-autoread list?</a>
-  <li><a href="#carlistfuture">Will there ever be a way to see who has you
-on their autoread list?</a>
-  <li><a href="#arlist">What is this three tiered Autoread list thing?</a>
-  <li><a href="#meter">What is the percent thing at the bottom of the Edit 
-Page?</a>
-  <li><a href="#htmltags">What basic HTML can I use in plans, and how do I
-use it?</a>
-  <li><a href="#additional">Are there additional things you can put in 
-your plan?</a>
-  <li><a href="#morehtml">Are you going to ever add in more html tags for
-plan users to use?</a>
-  <li><a href="#aboutregexp">What is this Reg. Exp. thing on the search
-page?</a>
-  <li><a href="#useregexp">How do I use Reg. Exp.?</a>
-  </ul>
-<li><a href="#privacy">Privacy on Plans:</a>
-  <ul>
-  <li><a href="#publicview">How private are my postings on Plans</a>
-</ul>
-</ul>
+                    <li><a href="#newplan">Getting a new plan:</a>
+                      <ul>
+                        <li><a href="#criteria">What criteria do I have to meet
+                            to be given a
+                            plan?</a>
+                          <li><a href="#groups">Can campus groups have plans?</a>
+                            <li><a href="#admin">Can administrators/faculty have
+                                plans?</a>
+                              <li><a href="#request">What do I do/Who do I
+                                  contact if I want a new
+                                  plan?</a>
+                              </ul>
+                              <li><a href="#features">About plan features:</a>
+                                <ul>
+                                  <li><a href="#links">How do I put in a link to
+                                      another person's
+                                      plan?</a>
+                                    <li><a href="#boardlinks">How do I put in a
+                                        link to a message on the
+                                        Notes board?</a>
+                                      <li><a href="#outside">How do I put in a
+                                          link to a webpage outside of
+                                          Plans?</a>
+                                        <li><a href="#carlist">Is there a way to
+                                            see who has you on their
+                                            autoread list?</a>
+                                          <li><a href="#carlistfuture">Will
+                                              there ever be a way to see who has
+                                              you
+                                              on their autoread list?</a>
+                                            <li><a href="#arlist">What is this
+                                                three tiered Autoread list
+                                                thing?</a>
+                                              <li><a href="#meter">What is the
+                                                  percent thing at the bottom of
+                                                  the Edit
+                                                  Page?</a>
+                                                <li><a href="#htmltags">What
+                                                    basic HTML can I use in
+                                                    plans, and how do I
+                                                    use it?</a>
+                                                  <li><a href="#additional">Are
+                                                      there additional things
+                                                      you can put in
+                                                      your plan?</a>
+                                                    <li><a href="#morehtml">Are
+                                                        you going to ever add in
+                                                        more html tags for
+                                                        plan users to use?</a>
+                                                      <li><a href="#aboutregexp">What
+                                                          is this Reg. Exp.
+                                                          thing on the search
+                                                          page?</a>
+                                                        <li><a href="#useregexp">How
+                                                            do I use Reg. Exp.?</a>
+                                                        </ul>
+                                                        <li><a href="#privacy">Privacy
+                                                            on Plans:</a>
+                                                          <ul>
+                                                            <li><a
+                                                                href="#publicview">How
+                                                                private are my
+                                                                postings on
+                                                                Plans</a>
+                                                            </ul>
+                                                          </ul>
 
-<hr>
+                                                          <hr>
 
-<h1><a name="history">Plan history:</a></h1>
-<h2><a name="plans">Where did plans come from?</a></h2>
+                                                          <h1><a name="history">Plan
+                                                              history:</a></h1>
+                                                          <h2><a name="plans">Where
+                                                              did plans come
+                                                              from?</a></h2>
 
-In the days of old, Grinnell College had a Vax computer system. One of the
-standard commands available on this system was called 'finger'. This
-command gave various information about a user, including showing the
-person's .plan file. Each user had their own .plan file, which was
-originally meant for people at companies and elsewhere to post what their
-work plans were. The .plan file at Grinnell College (and many other 
-places) gained a social aspect however. People started posting notes to 
-their friends, writing stories, or writing whatever else they felt like 
-writing. At Grinnell College, a small group of students called the 
-'VAXGods' wrote and maintained scripts to allow users to automatically 
-keep track of which of their friends had updated their .plan files. <br><br>
+                                                          In the days of old,
+                                                          Grinnell College had a
+                                                          Vax computer system.
+                                                          One of the
+                                                          standard commands
+                                                          available on this
+                                                          system was called
+                                                          'finger'. This
+                                                          command gave various
+                                                          information about a
+                                                          user, including
+                                                          showing the
+                                                          person's .plan file.
+                                                          Each user had their
+                                                          own .plan file, which
+                                                          was
+                                                          originally meant for
+                                                          people at companies
+                                                          and elsewhere to post
+                                                          what their
+                                                          work plans were. The
+                                                          .plan file at Grinnell
+                                                          College (and many
+                                                          other
+                                                          places) gained a
+                                                          social aspect however.
+                                                          People started posting
+                                                          notes to
+                                                          their friends, writing
+                                                          stories, or writing
+                                                          whatever else they
+                                                          felt like
+                                                          writing. At Grinnell
+                                                          College, a small group
+                                                          of students called the
+                                                          'VAXGods' wrote and
+                                                          maintained scripts to
+                                                          allow users to
+                                                          automatically
+                                                          keep track of which of
+                                                          their friends had
+                                                          updated their .plan
+                                                          files. <br><br>
 
-During the summer of 2000, the Vax at Grinnell College was phased out of
-operation. There was a time period in which no sort of plan system existed
-at Grinnell College. During this time period however, older students felt 
-a strong dismay over the loss of the popular plans system. Thoughts 
-floated around about creating a new web-based version of plans, and so 
-Rachel Heck ('01) was the first to take the initiative in creating a 
-web-based plan system.<br><Br>
+                                                          During the summer of
+                                                          2000, the Vax at
+                                                          Grinnell College was
+                                                          phased out of
+                                                          operation. There was a
+                                                          time period in which
+                                                          no sort of plan system
+                                                          existed
+                                                          at Grinnell College.
+                                                          During this time
+                                                          period however, older
+                                                          students felt
+                                                          a strong dismay over
+                                                          the loss of the
+                                                          popular plans system.
+                                                          Thoughts
+                                                          floated around about
+                                                          creating a new
+                                                          web-based version of
+                                                          plans, and so
+                                                          Rachel Heck ('01) was
+                                                          the first to take the
+                                                          initiative in creating
+                                                          a
+                                                          web-based plan system.<br><br>
 
-She wrote the original version (what we consider Plans v0) of the Grinnell
-web-based plans system with just a few friends in mind. The system grew
-very quickly in popularity. Since this original system was designed with
-only a few users in mind, problems started to arise with the swelling
-numbers of plan users. So in the spring of 2001, Rachel wrote a new
-version of plans (Plans v1) that had certain improvements, such as being
-backed by a database, with Andrew Kensler ('01) giving suggestions and
-writing the search page. In the spring of 2001 Rachel turned control of
-plans over to the current maintainers of plans. The current maintainers
-then significantly altered Plans v1, adding on certain customization
-abilities, and other abilities. By autumn 2001, it was apparent that the
-plan user base was becomming too large for the program to handle well, and
-so Plans v2 was introduced in the spring of 2002. During the 
-summer of 2003, events occured which led to Plans being hosted by 
-a commercial web host instead of being hosted by Grinnell College.<br><br>
+                                                          She wrote the original
+                                                          version (what we
+                                                          consider Plans v0) of
+                                                          the Grinnell
+                                                          web-based plans system
+                                                          with just a few
+                                                          friends in mind. The
+                                                          system grew
+                                                          very quickly in
+                                                          popularity. Since this
+                                                          original system was
+                                                          designed with
+                                                          only a few users in
+                                                          mind, problems started
+                                                          to arise with the
+                                                          swelling
+                                                          numbers of plan users.
+                                                          So in the spring of
+                                                          2001, Rachel wrote a
+                                                          new
+                                                          version of plans
+                                                          (Plans v1) that had
+                                                          certain improvements,
+                                                          such as being
+                                                          backed by a database,
+                                                          with Andrew Kensler ('01)
+                                                          giving suggestions and
+                                                          writing the search
+                                                          page. In the spring of
+                                                          2001 Rachel turned
+                                                          control of
+                                                          plans over to the
+                                                          current maintainers of
+                                                          plans. The current
+                                                          maintainers
+                                                          then significantly
+                                                          altered Plans v1,
+                                                          adding on certain
+                                                          customization
+                                                          abilities, and other
+                                                          abilities. By autumn
+                                                          2001, it was apparent
+                                                          that the
+                                                          plan user base was
+                                                          becomming too large
+                                                          for the program to
+                                                          handle well, and
+                                                          so Plans v2 was
+                                                          introduced in the
+                                                          spring of 2002. During
+                                                          the
+                                                          summer of 2003, events
+                                                          occured which led to
+                                                          Plans being hosted by
+                                                          a commercial web host
+                                                          instead of being
+                                                          hosted by Grinnell
+                                                          College.<br><br>
 
-<h2><a name="classproj">Is the program a class project, or a commercial
-product or what?</a></h2>
+                                                          <h2><a
+                                                              name="classproj">Is
+                                                              the program a
+                                                              class project, or
+                                                              a commercial
+                                                              product or what?</a></h2>
 
-Plans is not, nor ever was a class project (although we know of at least
-one class project that tried to come up with a better version of plans
-which failed). Running the plans system has very much been an educational
-experience to say the least. Anyway, plans are not a commercial project,
-but simply a student run um... something or other.<br><br><hr>
+                                                          Plans is not, nor ever
+                                                          was a class project
+                                                          (although we know of
+                                                          at least
+                                                          one class project that
+                                                          tried to come up with
+                                                          a better version of
+                                                          plans
+                                                          which failed). Running
+                                                          the plans system has
+                                                          very much been an
+                                                          educational
+                                                          experience to say the
+                                                          least. Anyway, plans
+                                                          are not a commercial
+                                                          project,
+                                                          but simply a student
+                                                          run um... something or
+                                                          other.<br><br><hr>
 
+                                                          <h1><a name="problems">Problems
+                                                              with Plans:</a></h1>
+                                                          <h2><a name="bug">What
+                                                              should I do if I
+                                                              find a bug in the
+                                                              program, have a
+                                                              comment, question
+                                                              or criticism, or
+                                                              if the program
+                                                              simply isn't
+                                                              working?</a></h2>
+                                                          Email
+                                                          grinnellplans@gmail.com<br><br>
 
-<h1><a name="problems">Problems with Plans:</a></h1>
-<h2><a name="bug">What should I do if I find a bug in the program, have a
-comment, question or criticism, or if the program simply isn't
-working?</a></h2>
-Email grinnellplans@gmail.com<br><br>
+                                                          <h2><a name="cookies">I
+                                                              can log in, but
+                                                              then when I click
+                                                              on anything
+                                                              it tells me that I
+                                                              am a guest, what
+                                                              should I do?</a></h2>
+                                                          The Plans system uses
+                                                          what are known as
+                                                          cookies, so that while
+                                                          you are
+                                                          logged into Plans you
+                                                          get the
+                                                          style/interface/etc.
+                                                          of your choosing, as
+                                                          well as giving you
+                                                          your autofinger list.
+                                                          However you can set
+                                                          your internet
+                                                          browser to not accept
+                                                          cookies. Normally the
+                                                          cookie takes effect
+                                                          after you
+                                                          receive the first page
+                                                          after you log in. If
+                                                          your browser is set to
+                                                          not
+                                                          accept cookies, then
+                                                          you can log in and get
+                                                          the first page as
+                                                          normal, but
+                                                          then if you click to
+                                                          receive any other
+                                                          page, Plans does not
+                                                          know who you
+                                                          are and so considers
+                                                          you a guest (you will
+                                                          see that the style
+                                                          reverts back
+                                                          to the default pastel
+                                                          color scheme).<br><br>
 
-<h2><a name="cookies">I can log in, but then when I click on anything
-it tells me that I am a guest, what should I do?</a></h2>
-The Plans system uses what are known as cookies, so that while you are 
-logged into Plans you get the style/interface/etc. of your choosing, as 
-well as giving you your autofinger list. However you can set your internet 
-browser to not accept cookies. Normally the cookie takes effect after you 
-receive the first page after you log in. If your browser is set to not 
-accept cookies, then you can log in and get the first page as normal, but 
-then if you click to receive any other page, Plans does not know who you 
-are and so considers you a guest (you will see that the style reverts back 
-to the default pastel color scheme).<br><Br>
+                                                          So what you need to do
+                                                          is check the settings
+                                                          on your browser and
+                                                          check the
+                                                          option to allow
+                                                          cookies. In some
+                                                          browsers if the
+                                                          security setting is
+                                                          set
+                                                          to the most protective
+                                                          you may need to lower
+                                                          the security a notch.
+                                                          Just
+                                                          remember to switch it
+                                                          back afterwards if you
+                                                          are wanting to keep
+                                                          that more
+                                                          protective setting
+                                                          while surfing the
+                                                          general internet.<br><br>
 
-So what you need to do is check the settings on your browser and check the 
-option to allow cookies. In some browsers if the security setting is set 
-to the most protective you may need to lower the security a notch. Just 
-remember to switch it back afterwards if you are wanting to keep that more 
-protective setting while surfing the general internet.<Br><br>
+                                                          [More specific
+                                                          instructions for each
+                                                          of the main browsers
+                                                          will eventually
+                                                          be put here.]<br><br>
 
-[More specific instructions for each of the main browsers will eventually 
-be put here.]<br><br>
+                                                          <h2><a name="cvs">Where
+                                                              can I get a copy
+                                                              of the source code
+                                                              for
+                                                              Plans?</a></h2>
+                                                          <a
+                                                            href="http://sourceforge.net/projects/grinnellplans">Plans
+                                                            CVS</a>
+                                                          (Click on the
+                                                          'Browse CVS' link near
+                                                          the bottom, and then
+                                                          select
+                                                          'grinnellplans').<br><br>
 
-<h2><a name="cvs">Where can I get a copy of the source code for 
-Plans?</a></h2>
-<a href="http://sourceforge.net/projects/grinnellplans">Plans CVS</a> 
-(Click on the 'Browse CVS' link near the bottom, and then select 
-'grinnellplans').<br><Br>
+                                                          <hr>
 
-<hr>
+                                                          <h1><a name="newplan">Getting
+                                                              a new plan:</a></h1>
+                                                          <h2><a name="criteria">What
+                                                              criteria do I have
+                                                              to meet to be
+                                                              given a
+                                                              plan?</a></h2>
+                                                          <ul>
+                                                            <li>Have previously
+                                                              or currently
+                                                              attended college
+                                                              in Grinnell, Iowa
+                                                              <li>Are a faculty
+                                                                member or staff
+                                                                worker at a
+                                                                Grinnell, Iowa
+                                                                college
+                                                                <li>Are
+                                                                  recognized as
+                                                                  a group by a
+                                                                  student
+                                                                  government of
+                                                                  a college in
+                                                                  Grinnell, Iowa
+                                                                </ul>
+                                                                <b>We do
+                                                                  however,
+                                                                  reserve the
+                                                                  right to
+                                                                  refuse a
+                                                                  person or
+                                                                  group an
+                                                                  account,
+                                                                  for any reason
+                                                                  regardless of
+                                                                  whether or not
+                                                                  they meet
+                                                                  these
+                                                                  criteria.
+                                                                  We also
+                                                                  reserve the
+                                                                  right to
+                                                                  remove an
+                                                                  account at any
+                                                                  time, for any
+                                                                  reason.</b>
 
+                                                                <h2><a
+                                                                    name="groups">Can
+                                                                    campus
+                                                                    groups have
+                                                                    plans?</a></h2>
+                                                                Yes, however we
+                                                                have no interest
+                                                                in determining
+                                                                who or what
+                                                                should be a
+                                                                group, and so we
+                                                                defer the
+                                                                determining of
+                                                                groups to SGA.
+                                                                To prove to us
+                                                                that you are an
+                                                                SGA recognized
+                                                                group, when
+                                                                requesting a
+                                                                plan, you must
+                                                                send the request
+                                                                e-mail from the
+                                                                group's email
+                                                                account (i.e.
+                                                                instead of
+                                                                sending the
+                                                                request from
+                                                                your personal
+                                                                email account,
+                                                                doejohn@grinnell.edu,
+                                                                you must send it
+                                                                from your group's
+                                                                email account,
+                                                                mygroup@grinnell.edu).<br><br>
 
-<h1><a name="newplan">Getting a new plan:</a></h1>
-<h2><a name="criteria">What criteria do I have to meet to be given a
-plan?</a></h2>
-<ul>
-<li>Have previously or currently attended college in Grinnell, Iowa
-<li>Are a faculty member or staff worker at a Grinnell, Iowa college
-<li>Are recognized as a group by a student government of a college in Grinnell, Iowa
-</ul>
-<b>We do however, reserve the right to refuse a person or group an 
-account, 
-for any reason regardless of whether or not they meet these criteria. 
-We also reserve the right to remove an account at any time, for any 
-reason.</b>
+                                                                <h2><a
+                                                                    name="admin">Can
+                                                                    administrators/faculty
+                                                                    of colleges
+                                                                    in Grinnell,
+                                                                    Iowa have
+                                                                    plans?</a></h2>Yes.<br><br>
 
-<h2><a name="groups">Can campus groups have plans?</a></h2>
-Yes, however we have no interest in determining who or what should be a
-group, and so we defer the determining of groups to SGA. To prove to us
-that you are an SGA recognized group, when requesting a plan, you must
-send the request e-mail from the group's email account (i.e. instead of
-sending the request from your personal email account,
-doejohn@grinnell.edu, you must send it from your group's email account,
-mygroup@grinnell.edu).<br><br>
+                                                                <h2><a
+                                                                    name="request">What
+                                                                    do I do/Who
+                                                                    do I contact
+                                                                    if I want a
+                                                                    new
+                                                                    plan?</a></h2>
+                                                                Our first
+                                                                request is that
+                                                                you read this
+                                                                faq, and browse
+                                                                Plans using the
+                                                                guest feature to
+                                                                get an idea of
+                                                                what Plans are
+                                                                about (currently
+                                                                disabled).
+                                                                Then if you want
+                                                                a plan, simply
+                                                                send an email
+                                                                with a brief
+                                                                message
+                                                                indicating that
+                                                                you'd like a
+                                                                plan to
+                                                                grinnellplans@gmail.com.
+                                                                If you
+                                                                are requesting a
+                                                                group account,
+                                                                please be sure
+                                                                to send the
+                                                                request from
+                                                                your groups
+                                                                email account.<br><br><hr>
 
-<h2><a name="admin">Can administrators/faculty of colleges in Grinnell, 
-Iowa have plans?</a></h2>Yes.<br><br>
+                                                                <h1><a
+                                                                    name="features">About
+                                                                    plan
+                                                                    features:</a></h1>
+                                                                <h2><a
+                                                                    name="links">How
+                                                                    do I put in
+                                                                    a link to
+                                                                    another
+                                                                    person's
+                                                                    plan?</a></h2>
+                                                                Simply put the
+                                                                person's
+                                                                username inside
+                                                                of brackets on
+                                                                your plan. i.e.
+                                                                to
+                                                                put a link to
+                                                                the plans plan,
+                                                                you would put
+                                                                [plans]
+                                                                somewhere on
+                                                                your
+                                                                plan.<br><br>
 
-<h2><a name="request">What do I do/Who do I contact if I want a new
-plan?</a></h2>
-Our first request is that you read this faq, and browse Plans using the
-guest feature to get an idea of what Plans are about (currently disabled). 
-Then if you want a plan, simply send an email with a brief message 
-indicating that you'd like a plan to grinnellplans@gmail.com. If you 
-are requesting a group account, please be sure to send the request from 
-your groups email account.<br><br><hr>
+                                                                <h2><a
+                                                                    name="boardlinks">How
+                                                                    do I put in
+                                                                    a link to a
+                                                                    message on
+                                                                    the Notes
+                                                                    board?</a></h2>
+                                                                When you view
+                                                                the messages
+                                                                within a thread,
+                                                                the number to
+                                                                the far left
+                                                                just under the
+                                                                title
+                                                                of the message
+                                                                is the id number
+                                                                of the message.
+                                                                To make a link
+                                                                that
+                                                                message, simply
+                                                                enclose
+                                                                the id number
+                                                                between square
+                                                                brackets. For
+                                                                example:<br>
+                                                                <br>
+                                                                [1]<br>
+                                                                <br>
+                                                                <h2><a
+                                                                    name="outside">How
+                                                                    do I put in
+                                                                    a link to a
+                                                                    webpage
+                                                                    outside of
+                                                                    Plans?</a></h2>
+                                                                There are
+                                                                several ways of
+                                                                making such a
+                                                                link. The first
+                                                                way is as
+                                                                such:<br> <br>
+                                                                [http://www.grinnellplans.com|Grinnell
+                                                                Plans
+                                                                Homepage]&nbsp;&nbsp;<br>
+                                                                <br>
+                                                                which will give
+                                                                you this: <a
+                                                                  href="http://www.grinnellplans.com">Grinnell
+                                                                  Plans
+                                                                  Homepage</a><br>
+                                                                <br>
+                                                                The second way
+                                                                is as such:<br>
+                                                                <br>
+                                                                [http://www.grinnellplans.com]<br>
+                                                                <br>
+                                                                Which will give
+                                                                you: <a
+                                                                  href="http://www.grinnellplans.com">http://www.grinnellplans.com</a><br>
+                                                                <br>
+                                                                The final way is
+                                                                as such:<br><br>
+                                                                &lt;a href="http://www.grinnellplans.com"&gt;Grinnell
+                                                                Plans&lt;/a&gt;<br><br>which
+                                                                will give you:
+                                                                <a
+                                                                  href="http://www.grinnellplans.com">Grinnell
+                                                                  Plans</a><br><br>
 
-<h1><a name="features">About plan features:</a></h1>
-<h2><a name="links">How do I put in a link to another person's
-plan?</a></h2>
-Simply put the person's username inside of brackets on your plan. i.e. to
-put a link to the plans plan, you would put [plans] somewhere on your
-plan.<br><br>
+                                                                <h2><a
+                                                                    name="carlist">Is
+                                                                    there a way
+                                                                    to see who
+                                                                    has you on
+                                                                    their
+                                                                    autoread
+                                                                    list?</a></h2>
+                                                                No, however to
+                                                                let you know the
+                                                                cause of the
+                                                                rumor you heard:
+                                                                in the
+                                                                distant past
+                                                                there had been
+                                                                ways, but these
+                                                                ways were never
+                                                                intended to be
+                                                                available for
+                                                                plan users to
+                                                                use.<br><br>
 
-<h2><a name="boardlinks">How do I put in a link to a message on the Notes 
-board?</a></h2>
-When you view the messages within a thread, the number to the far left 
-just under the title 
-of the message is the id number of the message. To make a link that 
-message, simply enclose 
-the id number between square brackets. For example:<br>
-<Br>
-[1]<br>
-<br>
-<h2><a name="outside">How do I put in a link to a webpage outside of 
-Plans?</a></h2>
-There are several ways of making such a link. The first way is as 
-such:<br> <Br>
-[http://www.grinnellplans.com|Grinnell Plans Homepage]&nbsp;&nbsp;<br>
-<br>
-which will give you this: <a href="http://www.grinnellplans.com">Grinnell 
-Plans 
-Homepage</a><br>
-<br>
-The second way is as such:<Br>
-<Br>
-[http://www.grinnellplans.com]<br>
-<br>
-Which will give you: <a 
-href="http://www.grinnellplans.com">http://www.grinnellplans.com</a><br>
-<br>
-The final way is as such:<br><br>
-&lt;a href="http://www.grinnellplans.com"&gt;Grinnell 
-Plans&lt;/a&gt;<br><br>which will give you: <a 
-href="http://www.grinnellplans.com">Grinnell Plans</a><br><br>
+                                                                <h2><a
+                                                                    name="carlistfuture">Will
+                                                                    there ever
+                                                                    be a way to
+                                                                    see who has
+                                                                    you on
+                                                                    their
+                                                                    autoread
+                                                                    list?</a></h2>
+                                                                No. We want to
+                                                                encourage people
+                                                                to read other
+                                                                people's plans
+                                                                without fear
+                                                                of other people
+                                                                knowing which
+                                                                plans they read,
+                                                                and to encourage
+                                                                people to
+                                                                write plans
+                                                                without
+                                                                censuring
+                                                                themselves based
+                                                                upon the
+                                                                knowledge of who
+                                                                reads their
+                                                                plan. Although
+                                                                in reality a
+                                                                public forum,
+                                                                plans tend to
+                                                                give
+                                                                people a sense
+                                                                of false
+                                                                secrecy, in
+                                                                which a plan
+                                                                writer is aware
+                                                                of the
+                                                                public nature of
+                                                                plans, but yet
+                                                                is allowed to,
+                                                                under the veil
+                                                                of false
+                                                                secrecy, to
+                                                                communicate
+                                                                things publicly
+                                                                which they would
+                                                                like to
+                                                                communicate, but
+                                                                which in regular
+                                                                public
+                                                                discourse, they
+                                                                may shy away
+                                                                from. Thus plans
+                                                                at times can
+                                                                reflect a very
+                                                                interesting side
+                                                                of Grinnell
+                                                                which otherwise
+                                                                might not be
+                                                                seen. As such,
+                                                                to allow the
+                                                                public to see
+                                                                who
+                                                                is on their
+                                                                autoread lists
+                                                                would is essence
+                                                                destroy plans.
+                                                                Therefor, we
+                                                                will never
+                                                                provide a way to
+                                                                see who is on
+                                                                your autoread
+                                                                list.<br><br>
 
-<h2><a name="carlist">Is there a way to see who has you on their autoread
-list?</a></h2>
-No, however to let you know the cause of the rumor you heard: in the
-distant past there had been ways, but these ways were never intended to be
-available for plan users to use.<br><br>
+                                                                <h2><a
+                                                                    name="arlist">What
+                                                                    is this
+                                                                    three tiered
+                                                                    Autoread
+                                                                    list
+                                                                    thing?</a></h2>
+                                                                The autoread
+                                                                list is a
+                                                                mechanism
+                                                                whereby a plan
+                                                                person can
+                                                                select which
+                                                                plans of other
+                                                                users interest
+                                                                them, and know
+                                                                if those plans
+                                                                have been
+                                                                updated since
+                                                                the person last
+                                                                read the users
+                                                                plan. For
+                                                                example, if you
+                                                                put
+                                                                me on your
+                                                                autoread list,
+                                                                and read my
+                                                                plan, then if
+                                                                afterwards I
+                                                                update my
+                                                                plan, you will
+                                                                see my username
+                                                                on your autoread
+                                                                list as having a
+                                                                new plan.
 
-<h2><a name="carlistfuture">Will there ever be a way to see who has you on
-their autoread list?</a></h2>
-No. We want to encourage people to read other people's plans without fear
-of other people knowing which plans they read, and to encourage people to
-write plans  without censuring themselves based upon the knowledge of who
-reads their plan. Although in reality a public forum, plans tend to give
-people a sense of false secrecy, in which a plan writer is aware of the
-public nature of plans, but yet is allowed to, under the veil of false
-secrecy, to communicate things publicly which they would like to
-communicate, but which in regular public discourse, they may shy away
-from. Thus plans at times can reflect a very interesting side of Grinnell
-which otherwise might not be seen. As such, to allow the public to see who
-is on their autoread lists would is essence destroy plans. Therefor, we
-will never provide a way to see who is on your autoread list.<br><br>
+                                                                In a way, the
+                                                                three tiered
+                                                                autoread list is
+                                                                almost like
+                                                                having three
+                                                                seperate
+                                                                autoread lists.
+                                                                It allows you to
+                                                                put the people
+                                                                in which you are
+                                                                most interested
+                                                                in keeping up
+                                                                with their plans
+                                                                in level 1, and
+                                                                the
+                                                                people that you
+                                                                are less
+                                                                interest in
+                                                                keeping up with
+                                                                in level 2, etc.
+                                                                This means that
+                                                                if you have only
+                                                                a limited amount
+                                                                of time to read
+                                                                plans,
+                                                                you can easily
+                                                                read the new
+                                                                plans of just
+                                                                those who you
+                                                                are most
+                                                                interested in.
+                                                                Please note that
+                                                                this is just one
+                                                                potential
+                                                                hierarchy that
+                                                                can be attached
+                                                                to the three
+                                                                tiered autoread
+                                                                list, and that
+                                                                you are free
+                                                                to use whatever
+                                                                categorization
+                                                                you wish. Also,
+                                                                remember that
+                                                                you can
+                                                                simply set
+                                                                everyone on your
+                                                                list to level 1
+                                                                and hence not
+                                                                have to bother
+                                                                with the three
+                                                                tiered system.<br><br>
 
-<h2><a name="arlist">What is this three tiered Autoread list
-thing?</a></h2>
-The autoread list is a mechanism whereby a plan person can select which
-plans of other users interest them, and know if those plans have been
-updated since the person last read the users plan. For example, if you put
-me on your autoread list, and read my plan, then if afterwards I update my
-plan, you will see my username on your autoread list as having a new plan.
+                                                                When there is a
+                                                                new plan that
+                                                                you haven't
+                                                                read, it will
+                                                                appear under the
+                                                                title of the
+                                                                level that you
+                                                                have selected.
+                                                                For instance if
+                                                                you have me
+                                                                on level 1, and
+                                                                I've updated my
+                                                                plan, when you
+                                                                click on level
+                                                                1, the
+                                                                title level 1
+                                                                will no longer
+                                                                be a link, but
+                                                                will now be a
+                                                                colored text,
+                                                                and under where
+                                                                it says level 1,
+                                                                you will see my
+                                                                username as a
+                                                                link
+                                                                that you can
+                                                                click to read my
+                                                                plan.
 
-In a way, the three tiered autoread list is almost like having three
-seperate autoread lists. It allows you to put the people in which you are
-most interested in keeping up with their plans in level 1, and the
-people that you are less interest in keeping up with in level 2, etc.
-This means that if you have only a limited amount of time to read plans,
-you can easily read the new plans of just those who you are most
-interested in. Please note that this is just one potential hierarchy that 
-can be attached to the three tiered autoread list, and that you are free 
-to use whatever categorization you wish. Also, remember that you can 
-simply set everyone on your list to level 1 and hence not have to bother 
-with the three tiered system.<br><br>
+                                                                To see what new
+                                                                plans there are
+                                                                for people on
+                                                                level 2, click
+                                                                on the
+                                                                level 2, and if
+                                                                there are any
+                                                                new plans, links
+                                                                to the new plans
+                                                                will
+                                                                appear under the
+                                                                colored text
+                                                                that says level
+                                                                2.<br><br>
 
-When there is a new plan that you haven't read, it will appear under the
-title of the level that you have selected. For instance if you have me
-on level 1, and I've updated my plan, when you click on level 1, the
-title level 1 will no longer be a link, but will now be a colored text,
-and under where it says level 1, you will see my username as a link
-that you can click to read my plan.
+                                                                <h2><a
+                                                                    name="meter">What
+                                                                    is the
+                                                                    percent
+                                                                    thing at the
+                                                                    bottom of
+                                                                    the Edit
+                                                                    Page?</a></h2>
+                                                                There is now a
+                                                                small meter
+                                                                displayed below
+                                                                your plan on the
+                                                                edit page. If
+                                                                you have a
+                                                                Javascript
+                                                                enabled browser
+                                                                it will show you
+                                                                <i>approximately</i>
+                                                                how close you
+                                                                are to the
+                                                                maximum plan
+                                                                size. If you
+                                                                exceed 100%, the
+                                                                bottom of your
+                                                                plan may be cut
+                                                                off. (Patch
+                                                                submitted by
+                                                                Andrew Kensler).<br><br>
 
-To see what new plans there are for people on level 2, click on the
-level 2, and if there are any new plans, links to the new plans will
-appear under the colored text that says level 2.<br><Br>
+                                                                <h2><a
+                                                                    name="htmltags">What
+                                                                    basic HTML
+                                                                    can I use in
+                                                                    plans, and
+                                                                    how do I
+                                                                    use it?</a></h2>
+                                                                Opening tags go
+                                                                inside of angle
+                                                                brackets, like
+                                                                this:
+                                                                &lt;tag&gt;
+                                                                <br>
+                                                                <br>For every
+                                                                opening tag,
+                                                                there must be a
+                                                                closing tag to
+                                                                match it, with
+                                                                the exception of
+                                                                the &lt;hr&gt;
+                                                                tag which will
+                                                                get replaced
+                                                                with a
+                                                                horizontal line.
+                                                                You close a
+                                                                tag by starting
+                                                                it with a slash:
+                                                                &lt;/tag&gt;
+                                                                <br>
+                                                                <br>There are
+                                                                three formatting
+                                                                tags available:
+                                                                <b>bold</b>
+                                                                &#60;b&#62;,
+                                                                <u>underline</u>
+                                                                &#60;u&#62;, and
+                                                                <i>italics</i>
+                                                                &#60;i&#62;.
+                                                                <br>
+                                                                <br>
+                                                                You can also use
+                                                                more than one
+                                                                tag at a time as
+                                                                I have done with
+                                                                the
+                                                                header of this
+                                                                section.
+                                                                <br>
+                                                                <br>&#60;b&#62;&#60;i&#62;This
+                                                                text is bold and
+                                                                italicized&#60;/i&#62;&#60/b&#62;
+                                                                <br>
+                                                                <br>becomes <b><i>This
+                                                                    text is bold
+                                                                    and
+                                                                    italicized</i>.</b>
+                                                                <br>
+                                                                <br>
+                                                                <br>If there are
+                                                                any questions
+                                                                about using the
+                                                                HTML tags for
+                                                                formatting
+                                                                your
+                                                                plan, please
+                                                                feel free to
+                                                                contact us at <i>grinnellplans@gmail.com</i>
+                                                                and
+                                                                we'll be happy
+                                                                to
+                                                                answer them.<br><br>
 
-<h2><a name="meter">What is the percent thing at the bottom of the Edit 
-Page?</a></h2>
-There is now a small meter displayed below your plan on the edit page.  If 
-you have a Javascript enabled browser it will show you 
-<i>approximately</i> how close you are to the maximum plan size.  If you 
-exceed 100%, the bottom of your plan may be cut off. (Patch submitted by 
-Andrew Kensler).<br><br>
+                                                                <h2><a
+                                                                    name="additional">Are
+                                                                    there
+                                                                    additional
+                                                                    things that
+                                                                    you can put
+                                                                    in
+                                                                    your plan?</a></h2>
+                                                                Yes, currently
+                                                                you can put
+                                                                [date] on your
+                                                                plan and then
+                                                                when you press
+                                                                the
+                                                                submit button it
+                                                                will get
+                                                                converted to the
+                                                                date and time at
+                                                                which you
+                                                                pressed the
+                                                                submit button.
+                                                                When you edit
+                                                                your plan again,
+                                                                the date and
+                                                                time will <b>not</b>
+                                                                be converted
+                                                                back to [date].<br><br>
 
-<h2><a name="htmltags">What basic HTML can I use in plans, and how do I
-use it?</a></h2>
-Opening tags go inside of angle brackets, like this:  &lt;tag&gt;
-<br>
-<br>For every opening tag, there must be a closing tag to match it, with 
-the exception of the &lt;hr&gt; tag which will get replaced with a 
-horizontal line.  You close a
-tag by starting it with a slash: &lt;/tag&gt;
-<br>
-<br>There are three formatting tags available: <b>bold</b> &#60;b&#62;,
-<u>underline</u> &#60;u&#62;, and <i>italics</i> &#60;i&#62;.  
-<br>
-<br>
-You can also use more than one tag at a time as I have done with the 
-header of this section.
-<br>
-<br>&#60;b&#62;&#60;i&#62;This text is bold and
-italicized&#60;/i&#62;&#60/b&#62;
-<br>
-<br>becomes <b><i>This text is bold and italicized</i>.</b>
-<br>
-<br>
-<br>If there are any questions about using the HTML tags for formatting
-your
-plan, please feel free to contact us at <i>grinnellplans@gmail.com</i> 
-and
-we'll be happy to
-answer them.<br><br>
+                                                                <h2><a
+                                                                    name="morehtml">Are
+                                                                    you going to
+                                                                    ever add in
+                                                                    more html
+                                                                    tags for
+                                                                    plan users
+                                                                    to use?</a></h2>
+                                                                At this time
+                                                                there are no
+                                                                plans to do so.
+                                                                Although we
+                                                                change the
+                                                                interface of
+                                                                plans, the
+                                                                central focus of
+                                                                plans remains
+                                                                the same in that
+                                                                it
+                                                                is about the
+                                                                text message
+                                                                that users wish
+                                                                to send out. The
+                                                                few html tags
+                                                                currently
+                                                                allowed seem
+                                                                adequate for
+                                                                allowing plan
+                                                                users to
+                                                                communicate in
+                                                                text.
+                                                                Furthermore, to
+                                                                be quite honest,
+                                                                disallowing html
+                                                                tags is quite
+                                                                easy, it is
+                                                                harder (and adds
+                                                                on significantly
+                                                                to processing
+                                                                power needed)
+                                                                to then allow
+                                                                html tags back
+                                                                in. So we want
+                                                                to keep the
+                                                                processing
+                                                                required to a
+                                                                reasonable
+                                                                amount (while at
+                                                                the same time
+                                                                not allowing
+                                                                people to put in
+                                                                whatever html
+                                                                they want), and
+                                                                so we are
+                                                                content with
+                                                                what
+                                                                is currently
+                                                                allowed.
 
-<h2><a name="additional">Are there additional things that you can put in 
-your plan?</a></h2>
-Yes, currently you can put [date] on your plan and then when you press the 
-submit button it will get converted to the date and time at which you 
-pressed the submit button. When you edit your plan again, the date and 
-time will <b>not</b> be converted back to [date].<br><br>
+                                                                <h2><a
+                                                                    name="aboutregexp">What
+                                                                    is this Reg.
+                                                                    Exp. thing
+                                                                    on the
+                                                                    search
+                                                                    page?</a></h2>
+                                                                Reg. Exp. is
+                                                                short for
+                                                                regular
+                                                                expressions. It's
+                                                                a way of
+                                                                describing a
+                                                                pattern in text.
+                                                                This gives you a
+                                                                much more
+                                                                flexible search.
 
-<h2><a name="morehtml">Are you going to ever add in more html tags for
-plan users to use?</a></h2>
-At this time there are no plans to do so. Although  we change the
-interface of plans, the central focus of plans remains the same in that it
-is about the text message that users wish to send out. The few html tags
-currently allowed seem adequate for allowing plan users to communicate in
-text. Furthermore, to be quite honest, disallowing html tags is quite
-easy, it is harder (and adds on significantly to processing power needed)
-to then allow html tags back in. So we want to keep the processing
-required to a reasonable amount (while at the same time not allowing
-people to put in whatever html they want), and so we are content with what
-is currently allowed.
+                                                                <h2><a
+                                                                    name="useregexp">How
+                                                                    do I use
+                                                                    Reg. Exp.?</a></h2>
+                                                                What follows
+                                                                is Andrew
+                                                                Kensler's
+                                                                explanation of
+                                                                how to use Reg.
+                                                                Exp.:
+                                                                <br><br>
+                                                                A . matches any
+                                                                character. For
+                                                                example, b.t
+                                                                will match "bit",
+                                                                "bat",
+                                                                "bot", "but",
+                                                                "bet", etc.
+                                                                <br>
+                                                                <br>Putting a
+                                                                series of
+                                                                characters in
+                                                                square brackets
+                                                                means that it
+                                                                will
+                                                                match any one of
+                                                                those letters.
+                                                                Thus you can
+                                                                write b[iaoe]t
+                                                                which will
+                                                                match "bit",
+                                                                "bat", "bot",
+                                                                "bet", etc., but
+                                                                not "but". You
+                                                                can also write
+                                                                a range using a
+                                                                hyphen, e.g.
+                                                                [0-9] will match
+                                                                any digit. If
+                                                                you put a ^
+                                                                right after the
+                                                                opening bracket,
+                                                                that means any
+                                                                character except
+                                                                those. So
+                                                                [^0-9a-z] means
+                                                                any character
+                                                                that's not a
+                                                                number or a
+                                                                letter.
+                                                                <br>
+                                                                <br>A ? after
+                                                                something means
+                                                                that whatever is
+                                                                just before it
+                                                                is optional
+                                                                and may or may
+                                                                not be there.
+                                                                Thus bo?at will
+                                                                match will match
+                                                                either
+                                                                "boat" or "bat".
+                                                                If you want to
+                                                                make more than
+                                                                one character
+                                                                optional,
+                                                                you can put it
+                                                                in parenthesis.
+                                                                Thus mount(ain)?
+                                                                matches either
+                                                                "mount" or
+                                                                "mountain.
+                                                                <br>
+                                                                <br>A * works
+                                                                similiarly
+                                                                except that it
+                                                                means that it
+                                                                matches
+                                                                something
+                                                                zero or more
+                                                                times. So ba*h
+                                                                will match "bh",
+                                                                "bah", "baah",
+                                                                "baaah",
+                                                                etc. Again, you
+                                                                can use
+                                                                parenthesis so
+                                                                b(an)*a will
+                                                                match "ba",
+                                                                "bana",
+                                                                "banana",
+                                                                "bananana", etc.
+                                                                <br>
+                                                                <br>If you want
+                                                                something like
+                                                                that but where
+                                                                it must appear
+                                                                at least
+                                                                once, use a +
+                                                                sign. Thus
+                                                                bana(na)+ will
+                                                                match "banana",
+                                                                "bananana",
+                                                                "banananana",
+                                                                etc. like above
+                                                                but not "banan"
+                                                                or "bana" or
+                                                                anything
+                                                                shorter.
+                                                                <br>
+                                                                <br>You can also
+                                                                give multiple
+                                                                possibilities
+                                                                and seperate
+                                                                them with a |
+                                                                Thus if you had
+                                                                a thing for
+                                                                fruit, you could
+                                                                search for
+                                                                banana|apple|pear|peach
+                                                                to find any of
+                                                                them.
+                                                                <br>
+                                                                <br>You can
+                                                                combine all of
+                                                                these however
+                                                                you like. You're
+                                                                welcome to
+                                                                search for
+                                                                (captain
+                                                                [0-9]+)|(b(an)*a)
+                                                                or something
+                                                                like that.
+                                                                <br>
+                                                                <br>One last
+                                                                little gotcha,
+                                                                though: if you
+                                                                want to search
+                                                                for any of these
+                                                                characters
+                                                                litterally, put
+                                                                a backslash, \,
+                                                                before the
+                                                                character. So if
+                                                                you really want
+                                                                to search for a
+                                                                question mark,
+                                                                use \? as the
+                                                                regular
+                                                                expression.
+                                                                <br><br>If this
+                                                                doesn't make
+                                                                sense, then just
+                                                                leave the Reg.
+                                                                Exp. box
+                                                                unchecked and it
+                                                                will search for
+                                                                whatever you
+                                                                typed literally.<br><br>
 
+                                                                <h1><a
+                                                                    name="privacy">Privacy
+                                                                    on Plans:</a></h1>
+                                                                <h2><a
+                                                                    name="publicview">How
+                                                                    private are
+                                                                    my postings
+                                                                    on Plans</a></h2>
+                                                                Plans is
+                                                                intended to be a
+                                                                private forum
+                                                                and anything
+                                                                said within
+                                                                Plans should, by
+                                                                default, be
+                                                                considered to be
+                                                                in confidence.
+                                                                We strongly
+                                                                discourage
+                                                                distributing any
+                                                                material outside
+                                                                of Plans without
+                                                                first gettting
+                                                                permission from
+                                                                the author.
+                                                                <br>
+                                                                <br>The outside
+                                                                world can only
+                                                                view your plan
+                                                                if you set it to
+                                                                be
+                                                                guest-readable
+                                                                in the
+                                                                preferences.
+                                                                However, Plans
+                                                                is only as
+                                                                secret as the
+                                                                least-trusted
+                                                                user and the
+                                                                administrators
+                                                                have no way to
+                                                                detect or
+                                                                intervene when
+                                                                someone does
+                                                                leak personal
+                                                                information.
 
-<h2><a name="aboutregexp">What is this Reg. Exp. thing on the search
-page?</a></h2>
-Reg. Exp. is short for regular expressions. It's a way of describing a
-pattern in text. This gives you a much more flexible search.
-
-<h2><a name="useregexp">How do I use Reg. Exp.?</a></h2>
-What follows
-is Andrew Kensler's explanation of how to use Reg. Exp.:
-<br><br>
-A . matches any character.  For example, b.t will match "bit", "bat",
-"bot", "but", "bet", etc.
-<br>
-<br>Putting a series of characters in square brackets means that it will
-match any one of those letters.  Thus you can write b[iaoe]t which will
-match "bit", "bat", "bot", "bet", etc., but not "but".  You can also write
-a range using a hyphen, e.g. [0-9] will match any digit.  If you put a ^
-right after the opening bracket, that means any character except
-those.  So [^0-9a-z] means any character that's not a number or a letter.  
-<br>
-<br>A ? after something means that whatever is just before it is optional
-and may or may not be there.  Thus bo?at will match will match either
-"boat" or "bat".  If you want to make more than one character optional,
-you can put it in parenthesis.  Thus mount(ain)? matches either "mount" or
-"mountain.
-<br>
-<br>A * works similiarly except that it means that it matches something
-zero or more times.  So ba*h will match "bh", "bah", "baah", "baaah",
-etc.  Again, you can use parenthesis so b(an)*a will match "ba", "bana",
-"banana", "bananana", etc.
-<br>
-<br>If you want something like that but where it must appear at least
-once, use a + sign.  Thus bana(na)+ will match "banana", "bananana",
-"banananana", etc. like above but not "banan" or "bana" or anything
-shorter.
-<br>
-<br>You can also give multiple possibilities and seperate them with a |
-Thus if you had a thing for fruit, you could search for
-banana|apple|pear|peach to find any of them.
-<br>
-<br>You can combine all of these however you like.  You're welcome to
-search for (captain [0-9]+)|(b(an)*a) or something like that.
-<br>
-<br>One last little gotcha, though: if you want to search for any of these
-characters litterally, put a backslash, \, before the character.  So if
-you really want to search for a question mark, use \? as the regular
-expression.
-<br><br>If this doesn't make sense, then just leave the Reg. Exp. box
-unchecked and it will search for whatever you typed literally.<br><br>
-
-<h1><a name="privacy">Privacy on Plans:</a></h1>
-  <h2><a name="publicview">How private are my postings on Plans</a></h2>
-Plans is intended to be a private forum and anything said within Plans should, by default, be considered to be in confidence.  We strongly discourage distributing any material outside of Plans without first gettting permission from the author.
-<br>
-<br>The outside world can only view your plan if you set it to be guest-readable in the preferences.  However, Plans is only as secret as the least-trusted user and the administrators have no way to detect or intervene when someone does leak personal information.
-
-</body>
-</html>
-
+                                                              </body>
+                                                            </html>

--- a/donations/donations.php
+++ b/donations/donations.php
@@ -6,7 +6,10 @@ include 'inc-error.php';
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html>
-  <head><title>Donations Made to Support Plans</title></head>
+  <head>
+    <title>Donations Made to Support Plans</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
   <body>
     <h2>Donations Made to Support Plans</h2>
     <hr />

--- a/index.php
+++ b/index.php
@@ -24,31 +24,12 @@ if (isset($_GET['logout'])) {
 <html dir="ltr">
 <head>
 	<title>GrinnellPlans</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style type="text/css">
-	<!--
-	BODY { 
-			font-family: verdana;
-			}
-	TD { 
-			align: center;
-			}
-	.boxes { 
-			font-family: courier; 
-			}
-	.buttons {
-			}
-	.graphic{
-			position: relative;
-			top: 50px;
-			}
-	.legalese {
-			position: static; 
-			text-align: justify;
-			cellpadding: 3;
-			font-size: 8pt;
-			font-family: verdana;
-			}
-	-->
+		img {
+			max-width: 100%;
+			height: auto;
+		}
 	</STYLE>
 <script src="https://www.google.com/jsapi" type="text/javascript"></script>
 <script type="text/javascript" charset="utf-8">

--- a/reset.php
+++ b/reset.php
@@ -1,6 +1,11 @@
 <?php
 require_once ('Plans.php');
-?><html><head><title>Reset Style Sheet</title></head><body><center>
+?><html>
+    <head>
+        <title>Reset Style Sheet</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+<body><center>
 
 <?php
 require ("functions-main.php");

--- a/tos/index.html
+++ b/tos/index.html
@@ -1,317 +1,644 @@
 <!DOCTYPE html>
 <html>
-<head>
-<title>GrinnellPlans Terms of Use</title>
-<meta charset="utf-8" />
-<style type="text/css">
-body {counter-reset: h2}
-h2:before {counter-increment: h2; content: counter(h2) ". "}
-h2.nocount:before {content: initial; counter-increment: none} 
-.head {text-align: center}
-p {text-indent: 3em; margin-top: 0.5em; margin-bottom: 0em;}
-h3 {margin-bottom:0em;}
-ol,ul {padding-left: 3em;}
-</style>
-</head>
-<body>
-<h1 class="head">
-GrinnellPlans Terms of Service
-</h1>
-<p class="head">
-Version 3.2
-</p>
-<p class="head">
-Last Modified: January 20, 2015
-</p>
-<h2>
-Acceptance of the Terms of Use
-</h2>
-<p>
-Welcome to the Website of GrinnellPlans (&ldquo;<b>GP</b>&rdquo;, &ldquo;<b>GrinnellPlans</b>&rdquo;, &ldquo;<b>we</b>&rdquo; or &ldquo;<b>us</b>&rdquo;). The following terms and conditions (these &ldquo;<b>Terms of Use</b>&rdquo;), govern your (&ldquo;<b>User</b>&rdquo;) access to and use of http://www.grinnellplans.com, including any content, functionality and services offered on or through http://www.grinnellplans.com (the &ldquo;Service&rdquo;).
-</p>
-<p>
-This site is not owned by, operated by, or officially affiliated with Grinnell College, Grinnell, IA.
-</p>
-<p>
-This site is monitored and kept operational by a team of volunteer site moderators (the &ldquo;<b>Administrators</b>&rdquo;).
-</p>
-<p>
-Please read the Terms of Use carefully before you start to use the Service. <b> By using the Service, you accept and agree to be bound and abide by these Terms of Use. </b> This Service is a web publishing service offered and available to Users who have registered (&ldquo;<b>Registered Users</b>&rdquo;) and guests (&ldquo;<b>Guest Users</b>&rdquo;).
-</p>
-<p>
-In order to become a Registered User, you must:
-<ol>
-<li>Have or had an @grinnell.edu email address; and</li>
-<li>Be at least sixteen (16) years of age.</li>
-</ol>
-</p>
-<p>
-Viewing, posting, and editing functions, among others, are available to Registered Users. By using this Service as a Registered User, you represent and warrant that you meet all of the foregoing eligibility requirements for Registered Users. If you do not meet all of these requirements, you may not access or use the Service as a Registered User.
-</p>
-<p>
-Viewing of public Plans is available to Guest Users. Guest Users must be at least sixteen (16) years of age to use the Service. By using this Service as a Guest User, you represent and warrant that you meet the foregoing eligibility requirement for Guest Users. If you do not meet the requirement, you may not access or use the Service as a Guest User.
-</p>
-<p>
-You are responsible for your own use of the Service, for any posts you make, and for any consequences thereof. <b> We encourage Users to operate under the principles of self-governance when interacting with other Users. </b>
-</p>
-<h2>
-Accessing the Service and Account Security
-</h2>
-<p>
-You are responsible for making all arrangements necessary for you to have access to the Service.
-</p>
-<h3>
-Creating an Account:
-</h3>
-<p>
-To access the Service or some of the resources it offers, you must register on the website. If you no longer have access to your grinnell.edu email address, you must email grinnellplans@gmail.com to set up your account. It is a condition of your use of the Service that all the information you provide when registering on the Service is accurate and complete.
-</p>
-<p>
-In addition to personal accounts, Users may request that the Administrators create publicly editable accounts for a specified purpose. These public accounts are generally meant to create a community space for particular topics or groups to share information and conversation.
-</p>
-<p>
-The Administrators may refuse to provide you with an account for any reason or no reason. If the Administrators do provide you with an account, you will receive a user name and password.
-</p>
-<h3>
-Personal Account Security:
-</h3>
-<p>
-You are responsible for safeguarding the password associated with your personal account. We encourage you to change your temporary password that the Administrators provide to you to a different, secret password. We encourage you to use a &ldquo;strong&rdquo; password that use a combination of upper and lower case letters, symbols, and numbers. You also acknowledge that your account is personal to you and agree to take responsibility for Content posted to your plan by people to whom you have given access to your account. We encourage you not to provide any other person with access to this Service or portions of it using your user name and password. You agree to notify us immediately of any potentially malicious unauthorized access to or use of your user name or password or any other breach of security. You should use particular caution when accessing your account from a public or shared computer so that others are not able to view or record your password or other personal information.
-</p>
-<h3>
-Public Account Security:
-</h3>
-<p>
-Where a user name and password has been created for a publicly editable Plan, that user name may only be used in connection with the intended purpose of the public account.
-</p>
-<h3>
-Privacy Settings
-</h3>
-<p>
-GP may offer the ability to control which other users of the Service have access to the Content you post on the Service. It is your responsibility to configure these settings. We do not guarantee the effectiveness of any controls offered. It is also your responsibility to select whether your Plan can be read by Guest Users.
-</p>
-<p class="c6 c10">
-</p>
-<h2>
-Intellectual Property Rights
-</h2>
-<h3>
-GP rights:
-</h3>
-<p>
-You acknowledge that GP owns all right, title and interest in and to the Service, including all intellectual property rights. The Service and its entire contents are protected by United States and international copyright, trademark, patent, trade secret and other intellectual property or proprietary rights laws. GrinnellPlans&#39; rights do NOT include third-party content used as part of the Service, including the content appearing on the Service.
-</p>
-<h3>
-User Rights:
-</h3>
-<p>
-GrinnellPlans claims no ownership or control over any materials submitted, posted or displayed by you on or through GrinnellPlans services (&ldquo;User Contributions&rdquo;). You or a third party licensor, as appropriate, retain all patent, trademark and copyright to any User Contributions on GrinnellPlans and you are responsible for protecting those rights, as appropriate. By submitting, posting or displaying User Contributions on or through GrinnellPlans services, which are intended to be available to the members of the public, you grant GrinnellPlans a worldwide, non-exclusive, royalty-free license to reproduce, publish and distribute such User Contributions on GrinnellPlans&#39; services for the purpose of displaying and distributing GrinnellPlans services. You represent and warrant that you have all the rights, power and authority necessary to convey these rights.
-</p>
-<p>
-GP reserves the right to refuse to accept, post, display or transmit any User Contributions in its sole discretion.
-</p>
-<p>
-You may choose to submit, post, and display any materials on or through GrinnellPlans under a public license (e.g. a Creative Commons license). GrinnellPlans is not a party to any such public license between you and any third party. GrinnellPlans may choose to exercise the rights granted under (a) the public license or licenses, if any, you apply to your materials or (b) this Agreement.
-</p>
-<h3>
-Copyright Infringement:
-</h3>
-<p>
-If you believe that any User Contributions violate your copyright, please see our Copyright Policy marked as Appendix B below for instructions on sending us a notice of copyright infringement. It is the policy of GrinnellPlans to terminate the user accounts of repeat infringers.
-</p>
-<h2>
-Prohibited Uses
-</h2>
-<p>
-You may use the Service only for lawful purposes and in accordance with these Terms of Use. You agree not to use the Service:
-</p>
-<ul>
-<li>In any way that violates any applicable federal, state, local or international law or regulation (including, without limitation, any laws regarding the export of data or software to and from the US or other countries).</li>
-<li>For the purpose of exploiting, harming or attempting to exploit or harm minors in any way by exposing them to inappropriate content, asking for personally identifiable information or otherwise.</li>
-<li>To transmit, or procure the sending of, any advertising or promotional material, including any &quot;junk mail&quot;, &quot;chain letter&quot;, or &quot;spam&quot; or any other similar solicitation.</li>
-<li>To collect and post other Users&rsquo; contact information, including but not limited to addresses, phone numbers, email addresses, or other modes of contact, on third-party websites.</li>
-<li>To maliciously impersonate or attempt to impersonate GrinnellPlans, a GrinnellPlans Administrator, another user or any other person or entity (including, without limitation, by using e-mail addresses associated with any of the foregoing).</li>
-<li>To engage in any other conduct which, as determined by us, may harm GP or Users of the Service, or may expose GP or Users to liability.</li>
-<li>Use the Service in any manner that could disable, overburden, damage, or impair the site or interfere with any other party&#39;s use of the Service, including their ability to engage in real time activities through the Service.</li>
-<li>Except with regard to your personal plan, use any robot, spider or other automatic device, process, or means to access the Service for any purpose, including monitoring or copying any of the material on the Service, without express prior written consent of the GrinnellPlans Administrators.</li>
-<li>Maliciously use any manual process to monitor or copy any of the material on the Service for unauthorized purposes.</li>
-<li>Otherwise attempt to interfere with the proper working of the Service.</li>
-</ul>
-<h2>
-Monitoring and Enforcement
-</h2>
-<h3>
-Termination
-</h3>
-<p>
-We have the right to:
-</p>
-<ul>
-<li>Terminate or suspend Users for any reason in our sole discretion.</li>
-<li>Terminate or suspend Users who intentionally and maliciously circumvent any security or authentication measures or any features intended to block or limit contact between Users.</li>
-<li>Take any action with respect to any User Contribution that we deem necessary or appropriate in our sole discretion, including if we believe that such User Contribution violates the Terms of Use, including the Content Standards, infringes any intellectual property right or other right of any person or entity, threatens the personal safety of Users of the Service or the public or could create liability for GrinnellPlans.</li>
-<li>Disclose your identity or other information about you to any third party who claims that material posted by you violates their rights, including their intellectual property rights or their right to privacy.</li>
-<li>Take appropriate legal action, including without limitation, referral to law enforcement, for any illegal use of the Service.</li>
-<li>Terminate or suspend your access to all or part of the Service for any reason, including without limitation, any violation of these Terms of Use.</li>
-</ul>
-<h3>
-Investigation
-</h3>
-<p>
-GrinnellPlans reserves the right, but shall have no obligation, to investigate your use of the Service in order to determine whether a violation of the Agreement has occurred. Where GrinnellPlans chooses to conduct an investigation, it will use the investigation procedure described in Appendix A, or another procedure appropriate for the circumstances, in its own discretion.
-</p>
-<p>
-Without limiting the foregoing, we have the right to fully cooperate with any law enforcement authorities or court order requesting or directing us to disclose the identity or other information of anyone posting any materials on or through the Service. YOU WAIVE AND HOLD HARMLESS GRINNELLPLANS FROM ANY CLAIMS RESULTING FROM ANY ACTION TAKEN BY GRINNELLPLANS DURING OR AS A RESULT OF ITS INVESTIGATIONS AND FROM ANY ACTIONS TAKEN AS A CONSEQUENCE OF INVESTIGATIONS BY EITHER GRINNELLPLANS OR LAW ENFORCEMENT AUTHORITIES.
-</p>
-<h2>
-Content Standards
-</h2>
-<p>
-These content standards apply to any and all User Contributions. User Contributions must in their entirety comply with all applicable federal, state, local and international laws and regulations. Without limiting the foregoing, User Contributions must not:
-</p>
-<ul>
-<li>Contain any material which is defamatory, obscene, indecent, abusive, offensive, harassing, violent, hateful, inflammatory or otherwise objectionable;</li>
-<li>Contain any material which promotes violence or discrimination based on race, sex, gender, religion, nationality, disability, occupation, sexual orientation or age;</li>
-<li>Infringe any patent, trademark, trade secret, copyright or other intellectual property or other rights of any other person;</li>
-<li>Violate the legal rights (including the rights of publicity and privacy) of others;</li>
-<li>Contain any material that could give rise to any civil or criminal liability under applicable laws or regulations or that otherwise may be in conflict with these Terms of Use;</li>
-<li>Materially misrepresent that they emanate from or are endorsed by us or any other person or entity, if this is not the case.</li>
-</ul>
-<p>
-User Contributions to Secrets must conform to the following standards:
-</p>
-<ol>
-<li>Your post must be a secret.</li>
-<li>The secret must be your own.</li>
-<li>The secret may not reference any person or group in any identifiable way.</li>
-</ol>
-<h2>
-Indemnification
-</h2>
-<p>
-You understand and acknowledge that you are responsible for any User Contributions or Content you submit or contribute, and you, not GrinnellPlans, have full responsibility for such content.
-</p>
-<p>
-To the maximum extent allowable by law, we are not responsible, or liable to any third party, for the content or accuracy of any User Contributions posted by you or any other user of the Service. Consequently, GrinnellPlans.com may carry offensive, harmful, inaccurate or otherwise inappropriate material, or in some cases, postings that have been mislabeled or are otherwise deceptive. We expect that you will use caution and common sense and exercise proper judgment when using the Service.
-</p>
-<p>
-With regard to individual Plans, we cannot review material before it is posted on the Service, and cannot ensure removal of objectionable material after it has been posted. Accordingly, we assume no liability for any action or inaction regarding transmissions, communications or content provided by any User or third party. We have no liability or responsibility to anyone for performance or nonperformance of the activities described in this section.
-</p>
-<p>
-With regard to the Secrets section, we review material before it is posted on the Service, and make reasonable efforts to ensure prompt removal of objectionable material if it has been posted. However, we assume no liability for any action or inaction regarding transmissions, communications or content provided by any user or third party. We have no liability or responsibility to anyone for performance or nonperformance of the activities described in this section.
-</p>
-<p>
-If anyone brings a claim against us related to your actions, content or information on GrinnellPlans, you will indemnify and hold us harmless from and against all damages, losses, and expenses of any kind (including reasonable legal fees and costs) related to such claim.
-</p>
-<h2>
-Disclaimer
-</h2>
-<p>
-You understand and agree that the Service is provided to you on an AS IS and AS AVAILABLE basis. To the maximum extent allowable by law, GP disclaims all responsibility and liability for the availability, timeliness, security or reliability of the Service or any other client software. GP also reserves the right to modify, suspend or discontinue the Service with or without notice at any time and without any liability to you.
-</p>
-<h2>
-Governing Law and Jurisdiction
-</h2>
-<p>
-All matters relating to the Service and these Terms of Use and any dispute or claim arising therefrom or related thereto (in each case, including non-contractual disputes or claims), shall be governed by and construed in accordance with the internal laws of the State of Illinois without giving effect to any choice or conflict of law provision or rule (whether of the State of Illinois or any other jurisdiction).
-</p>
-<p>
-All claims, legal proceedings or litigation arising in connection with the Service will be brought solely in the federal or state courts located in Cook County, Illinois, United States, although we retain the right to bring any suit, action or proceeding against you for breach of these Terms of Use in your country of residence or any other relevant country. You waive any and all objections to the exercise of jurisdiction over you by such courts and to venue in such courts.
-</p>
-<h2>
-Changes to the Terms of Use
-</h2>
-<p>
-We may revise and update these Terms of Use from time to time in our sole discretion. All changes are effective immediately when we post them, and apply to all access to and use of the Service thereafter. Notice of changes posted on the homepage is to be considered sufficient notice to you.
-</p>
-<h2>
-Waiver and Severability
-</h2>
-<p>
-No waiver by GrinnellPlans of any term or condition set forth in these Terms of Use shall be deemed a further or continuing waiver of such term or condition or a waiver of any other term or condition. Failure of GrinnellPlans to assert a right or provision under these Terms of Use shall not constitute a waiver of such right or provision.
-</p>
-<p>
-If any provision of these Terms of Use is held by a court or other tribunal of competent jurisdiction to be invalid, illegal or unenforceable for any reason, such provision shall be eliminated or limited to the minimum extent such that the remaining provisions of the Terms of Use will continue in full force and effect.
-</p>
-<h2>
-Entire Agreement
-</h2>
-<p>
-The Terms of Use and referenced appendices constitute the sole and entire agreement between you and GrinnellPlans with respect to the Service and supersede all prior and contemporaneous understandings, agreements, representations and warranties, both written and oral, with respect to the Service.
-</p>
-<h2>
-Your Comments and Concerns
-</h2>
-<p>
-All feedback, comments, requests for technical support and other communications relating to the Service should be directed to: grinnellplans@gmail.com.
-</p>
-<p>
-Thank you for visiting GrinnellPlans. Please govern yourself accordingly.
-</p>
-<hr />
-<h2 class="nocount">
-Appendix A: Investigation Procedure
-</h2>
-<p>
-The Investigation Procedure described below is a protocol for the investigation of concerns voiced by Users. The Grinnell Plans Administrators have identified these steps as a general roadmap for investigations in order to maximize fair and informed decision-making. But Admin are not bound to use the procedure. An investigation may deviate from it or disregard it in any investigation when circumstances, in Administrators&#39; discretion, warrant. Termination (or other administrative action) based on a violation of the Terms of Service may be effected without an investigation, or with an investigation conducted in some other fashion.
-</p>
-<ol>
-<li>Complaints are emailed to grinnellplans@gmail.com</li>
-<li>Plans Administrators open an investigation period, and allow individuals to confidentially voice their grievances in case incident is not isolated to an individual or group.</li>
-<li>Complainants and respondents are contacted and asked to share their side of the story. Our emails and the subsequent responses are archived.</li>
-<li>At the close of the comment period, a quorum (80%) of Grinnell Administrators discuss grievances, evidence provided, and if needed, contacts a legal representative to advise.</li>
-<li>Administrators discuss short term, medium term, and long term solutions.</li>
-<li>At the end of meetings, an email containing the minutes of that meeting are disseminated to the Administrators. Those minutes are confidential, and are not shared with either the complainant or respondent.</li>
-<li>The same quorum (80%) of Administrators makes a collective decision based off of information that is available that best fits the needs of the community and maintains a safe environment.</li>
-</ol>
-<hr />
-<h2 class="nocount">
-Appendix B: Digital Millennium Copyright Act.
-</h2>
-<p>
-It is our policy to respond to clear notices of alleged copyright infringement. This page describes the information that should be present in these notices. It is designed to make submitting notices of alleged infringement to GrinnellPlans as straightforward as possible while reducing the number of notices that we receive that are fraudulent or difficult to understand or verify. The form of notice specified below is consistent with the form suggested by the United States Digital Millennium Copyright Act (the text of which can be found at the U.S. Copyright Office Web Site, http://www.copyright.gov) but we will respond to notices of this form from other jurisdictions as well.
-</p>
-<p>
-Regardless of whether we may be liable for such infringement under local country law or United States law, our response to these notices may include removing or disabling access to material claimed to be the subject of infringing activity and/or terminating subscribers. If we remove or disable access in response to such a notice, we will make a good-faith attempt to contact the owner or administrator of the affected site or content so that they may make a counter notification. We may also document notices of alleged infringement on which we act. As with all legal notices, a copy of the notice may be sent to one or more third parties who may make it available to the public.
-</p>
-<h3>
-Infringement Notification:
-</h3>
-<p>
-To file a notice of infringement with us, you must provide a written communication by email to grinnellplans@gmail.com that sets forth the items specified below. Please note that you will be liable for damages (including costs and attorneys&#39; fees) if you materially misrepresent that a product or activity is infringing your copyrights. Indeed, in a recent case (please see http://www.onlinepolicy.org/action/legpolicy/opg_v_diebold/ for more information), a company that sent an infringement notification seeking removal of online materials that were protected by the fair use doctrine was ordered to pay such costs and attorneys fees. The company agreed to pay over $100,000. If you are uncertain whether material available online infringes your copyright, consult your attorney.
-</p>
-<p>
-To expedite our ability to process your request, please use the following format (including section numbers):
-</p>
-<ol>
-<li>Identify in sufficient detail the copyrighted work that you believe has been infringed upon. This post must include identification of the specific posts, as opposed to entire sites. Posts must be referenced by the permalink of the post. For example, &ldquo;The copyrighted work at issue is the text that appears on http://johndoe.com/test/2006_01_01.html#2106.</li>
-<li>Identify the material that you claim is infringing the copyrighted work listed in item #1 above.<br />
-YOU MUST IDENTIFY EACH POST BY PERMALINK OR DATE THAT ALLEGEDLY CONTAINS THE INFRINGING MATERIAL. The permalink for a post is usually found by clicking on the timestamp of the post. For example, &ldquo;The blog where my copyrighted work is published on is http://copyright.grinnellplans.com/archives/2006_01_02_example.html.&rdquo;</li>
-<li>Provide information reasonably sufficient to permit GrinnellPlans to contact you (email address is preferred).</li>
-<li>Include the following statement: &quot;I have a good faith belief that use of the copyrighted material described above on the allegedly infringing web pages is not authorized by the copyright owner, its agent, or the law.&quot;.</li>
-<li>Include the following statement: &quot;I swear, under penalty of perjury, that the information in the notification is accurate and that I am the copyright owner or am authorized to act on behalf of the owner of an exclusive right that is allegedly infringed.&quot;</li>
-<li>Sign the document. Electronic signatures are sufficient.</li>
-</ol>
-<h3>
-Counter Notification
-</h3>
-<p>
-The administrator of an affected site or the provider of affected content may make a counter notification pursuant to sections 512(g)(2) and (3) of the Digital Millennium Copyright Act. When we receive a counter notification, we may reinstate the material in question.
-</p>
-<p>
-To file a counter notification with us, you must provide an email to grinnellplans@gmail.com that sets forth the items specified below. Please note that you will be liable for damages (including costs and attorneys&#39; fees) if you materially misrepresent that a product or activity is not infringing the copyrights of others. Accordingly, if you are not sure whether certain material infringes the copyrights of others, consult your attorney.
-</p>
-<p>
-To expedite our ability to process your counter notification, please use the following format (including section numbers):
-</p>
-<ol>
-<li>Identify the specific URLs or other unique identifying information of material that GrinnellPlans has removed or to which GrinnellPlans has disabled access.</li>
-<li>Provide your name, address, telephone number, email address, and a statement that you consent to the jurisdiction of Federal District Court for the judicial district in which your address is located, and that you will accept service of process from the person who provided notification under subsection (c)(1)(C) or an agent of such person.</li>
-<li>Include the following statement: &quot;I swear, under penalty of perjury, that I have a good faith belief that each search result, message, or other item of content identified above was removed or disabled as a result of a mistake or misidentification of the material to be removed or disabled, or that the material identified by the complainant has been removed or disabled at the URL identified and will no longer be shown.&quot;</li>
-<li>Sign the paper. Electronic signatures are sufficient.</li>
-</ol>
-<p>
-GrinnellPlans will, in appropriate circumstances, terminate repeat infringers. If you believe that an account holder or subscriber is a repeat infringer, please follow the instructions above to contact GrinnellPlans&#39;s DMCA agent and provide information sufficient for us to verify that the account holder or subscriber is a repeat infringer.
-</p>
-</body>
+    <head>
+        <title>GrinnellPlans Terms of Use</title>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style type="text/css">
+            body {counter-reset: h2}
+            h2:before {counter-increment: h2; content: counter(h2) ". "}
+            h2.nocount:before {content: initial; counter-increment: none} 
+            .head {text-align: center}
+            p {text-indent: 3em; margin-top: 0.5em; margin-bottom: 0em;}
+            h3 {margin-bottom:0em;}
+            ol,ul {padding-left: 3em;}
+        </style>
+    </head>
+    <body>
+        <h1 class="head">
+            GrinnellPlans Terms of Service
+        </h1>
+        <p class="head">
+            Version 3.2
+        </p>
+        <p class="head">
+            Last Modified: January 20, 2015
+        </p>
+        <h2>
+            Acceptance of the Terms of Use
+        </h2>
+        <p>
+            Welcome to the Website of GrinnellPlans (&ldquo;<b>GP</b>&rdquo;,
+            &ldquo;<b>GrinnellPlans</b>&rdquo;, &ldquo;<b>we</b>&rdquo; or
+            &ldquo;<b>us</b>&rdquo;). The following terms and conditions (these
+            &ldquo;<b>Terms of Use</b>&rdquo;), govern your (&ldquo;<b>User</b>&rdquo;)
+            access to and use of http://www.grinnellplans.com, including any
+            content, functionality and services offered on or through
+            http://www.grinnellplans.com (the &ldquo;Service&rdquo;).
+        </p>
+        <p>
+            This site is not owned by, operated by, or officially affiliated
+            with Grinnell College, Grinnell, IA.
+        </p>
+        <p>
+            This site is monitored and kept operational by a team of volunteer
+            site moderators (the &ldquo;<b>Administrators</b>&rdquo;).
+        </p>
+        <p>
+            Please read the Terms of Use carefully before you start to use the
+            Service. <b> By using the Service, you accept and agree to be bound
+                and abide by these Terms of Use. </b> This Service is a web
+            publishing service offered and available to Users who have
+            registered (&ldquo;<b>Registered Users</b>&rdquo;) and guests
+            (&ldquo;<b>Guest Users</b>&rdquo;).
+        </p>
+        <p>
+            In order to become a Registered User, you must:
+            <ol>
+                <li>Have or had an @grinnell.edu email address; and</li>
+                <li>Be at least sixteen (16) years of age.</li>
+            </ol>
+        </p>
+        <p>
+            Viewing, posting, and editing functions, among others, are available
+            to Registered Users. By using this Service as a Registered User, you
+            represent and warrant that you meet all of the foregoing eligibility
+            requirements for Registered Users. If you do not meet all of these
+            requirements, you may not access or use the Service as a Registered
+            User.
+        </p>
+        <p>
+            Viewing of public Plans is available to Guest Users. Guest Users
+            must be at least sixteen (16) years of age to use the Service. By
+            using this Service as a Guest User, you represent and warrant that
+            you meet the foregoing eligibility requirement for Guest Users. If
+            you do not meet the requirement, you may not access or use the
+            Service as a Guest User.
+        </p>
+        <p>
+            You are responsible for your own use of the Service, for any posts
+            you make, and for any consequences thereof. <b> We encourage Users
+                to operate under the principles of self-governance when
+                interacting with other Users. </b>
+        </p>
+        <h2>
+            Accessing the Service and Account Security
+        </h2>
+        <p>
+            You are responsible for making all arrangements necessary for you to
+            have access to the Service.
+        </p>
+        <h3>
+            Creating an Account:
+        </h3>
+        <p>
+            To access the Service or some of the resources it offers, you must
+            register on the website. If you no longer have access to your
+            grinnell.edu email address, you must email grinnellplans@gmail.com
+            to set up your account. It is a condition of your use of the Service
+            that all the information you provide when registering on the Service
+            is accurate and complete.
+        </p>
+        <p>
+            In addition to personal accounts, Users may request that the
+            Administrators create publicly editable accounts for a specified
+            purpose. These public accounts are generally meant to create a
+            community space for particular topics or groups to share information
+            and conversation.
+        </p>
+        <p>
+            The Administrators may refuse to provide you with an account for any
+            reason or no reason. If the Administrators do provide you with an
+            account, you will receive a user name and password.
+        </p>
+        <h3>
+            Personal Account Security:
+        </h3>
+        <p>
+            You are responsible for safeguarding the password associated with
+            your personal account. We encourage you to change your temporary
+            password that the Administrators provide to you to a different,
+            secret password. We encourage you to use a &ldquo;strong&rdquo;
+            password that use a combination of upper and lower case letters,
+            symbols, and numbers. You also acknowledge that your account is
+            personal to you and agree to take responsibility for Content posted
+            to your plan by people to whom you have given access to your
+            account. We encourage you not to provide any other person with
+            access to this Service or portions of it using your user name and
+            password. You agree to notify us immediately of any potentially
+            malicious unauthorized access to or use of your user name or
+            password or any other breach of security. You should use particular
+            caution when accessing your account from a public or shared computer
+            so that others are not able to view or record your password or other
+            personal information.
+        </p>
+        <h3>
+            Public Account Security:
+        </h3>
+        <p>
+            Where a user name and password has been created for a publicly
+            editable Plan, that user name may only be used in connection with
+            the intended purpose of the public account.
+        </p>
+        <h3>
+            Privacy Settings
+        </h3>
+        <p>
+            GP may offer the ability to control which other users of the Service
+            have access to the Content you post on the Service. It is your
+            responsibility to configure these settings. We do not guarantee the
+            effectiveness of any controls offered. It is also your
+            responsibility to select whether your Plan can be read by Guest
+            Users.
+        </p>
+        <p class="c6 c10">
+        </p>
+        <h2>
+            Intellectual Property Rights
+        </h2>
+        <h3>
+            GP rights:
+        </h3>
+        <p>
+            You acknowledge that GP owns all right, title and interest in and to
+            the Service, including all intellectual property rights. The Service
+            and its entire contents are protected by United States and
+            international copyright, trademark, patent, trade secret and other
+            intellectual property or proprietary rights laws. GrinnellPlans&#39;
+            rights do NOT include third-party content used as part of the
+            Service, including the content appearing on the Service.
+        </p>
+        <h3>
+            User Rights:
+        </h3>
+        <p>
+            GrinnellPlans claims no ownership or control over any materials
+            submitted, posted or displayed by you on or through GrinnellPlans
+            services (&ldquo;User Contributions&rdquo;). You or a third party
+            licensor, as appropriate, retain all patent, trademark and copyright
+            to any User Contributions on GrinnellPlans and you are responsible
+            for protecting those rights, as appropriate. By submitting, posting
+            or displaying User Contributions on or through GrinnellPlans
+            services, which are intended to be available to the members of the
+            public, you grant GrinnellPlans a worldwide, non-exclusive,
+            royalty-free license to reproduce, publish and distribute such User
+            Contributions on GrinnellPlans&#39; services for the purpose of
+            displaying and distributing GrinnellPlans services. You represent
+            and warrant that you have all the rights, power and authority
+            necessary to convey these rights.
+        </p>
+        <p>
+            GP reserves the right to refuse to accept, post, display or transmit
+            any User Contributions in its sole discretion.
+        </p>
+        <p>
+            You may choose to submit, post, and display any materials on or
+            through GrinnellPlans under a public license (e.g. a Creative
+            Commons license). GrinnellPlans is not a party to any such public
+            license between you and any third party. GrinnellPlans may choose to
+            exercise the rights granted under (a) the public license or
+            licenses, if any, you apply to your materials or (b) this Agreement.
+        </p>
+        <h3>
+            Copyright Infringement:
+        </h3>
+        <p>
+            If you believe that any User Contributions violate your copyright,
+            please see our Copyright Policy marked as Appendix B below for
+            instructions on sending us a notice of copyright infringement. It is
+            the policy of GrinnellPlans to terminate the user accounts of repeat
+            infringers.
+        </p>
+        <h2>
+            Prohibited Uses
+        </h2>
+        <p>
+            You may use the Service only for lawful purposes and in accordance
+            with these Terms of Use. You agree not to use the Service:
+        </p>
+        <ul>
+            <li>In any way that violates any applicable federal, state, local or
+                international law or regulation (including, without limitation,
+                any laws regarding the export of data or software to and from
+                the US or other countries).</li>
+            <li>For the purpose of exploiting, harming or attempting to exploit
+                or harm minors in any way by exposing them to inappropriate
+                content, asking for personally identifiable information or
+                otherwise.</li>
+            <li>To transmit, or procure the sending of, any advertising or
+                promotional material, including any &quot;junk mail&quot;,
+                &quot;chain letter&quot;, or &quot;spam&quot; or any other
+                similar solicitation.</li>
+            <li>To collect and post other Users&rsquo; contact information,
+                including but not limited to addresses, phone numbers, email
+                addresses, or other modes of contact, on third-party websites.</li>
+            <li>To maliciously impersonate or attempt to impersonate
+                GrinnellPlans, a GrinnellPlans Administrator, another user or
+                any other person or entity (including, without limitation, by
+                using e-mail addresses associated with any of the foregoing).</li>
+            <li>To engage in any other conduct which, as determined by us, may
+                harm GP or Users of the Service, or may expose GP or Users to
+                liability.</li>
+            <li>Use the Service in any manner that could disable, overburden,
+                damage, or impair the site or interfere with any other
+                party&#39;s use of the Service, including their ability to
+                engage in real time activities through the Service.</li>
+            <li>Except with regard to your personal plan, use any robot, spider
+                or other automatic device, process, or means to access the
+                Service for any purpose, including monitoring or copying any of
+                the material on the Service, without express prior written
+                consent of the GrinnellPlans Administrators.</li>
+            <li>Maliciously use any manual process to monitor or copy any of the
+                material on the Service for unauthorized purposes.</li>
+            <li>Otherwise attempt to interfere with the proper working of the
+                Service.</li>
+        </ul>
+        <h2>
+            Monitoring and Enforcement
+        </h2>
+        <h3>
+            Termination
+        </h3>
+        <p>
+            We have the right to:
+        </p>
+        <ul>
+            <li>Terminate or suspend Users for any reason in our sole
+                discretion.</li>
+            <li>Terminate or suspend Users who intentionally and maliciously
+                circumvent any security or authentication measures or any
+                features intended to block or limit contact between Users.</li>
+            <li>Take any action with respect to any User Contribution that we
+                deem necessary or appropriate in our sole discretion, including
+                if we believe that such User Contribution violates the Terms of
+                Use, including the Content Standards, infringes any intellectual
+                property right or other right of any person or entity, threatens
+                the personal safety of Users of the Service or the public or
+                could create liability for GrinnellPlans.</li>
+            <li>Disclose your identity or other information about you to any
+                third party who claims that material posted by you violates
+                their rights, including their intellectual property rights or
+                their right to privacy.</li>
+            <li>Take appropriate legal action, including without limitation,
+                referral to law enforcement, for any illegal use of the Service.</li>
+            <li>Terminate or suspend your access to all or part of the Service
+                for any reason, including without limitation, any violation of
+                these Terms of Use.</li>
+        </ul>
+        <h3>
+            Investigation
+        </h3>
+        <p>
+            GrinnellPlans reserves the right, but shall have no obligation, to
+            investigate your use of the Service in order to determine whether a
+            violation of the Agreement has occurred. Where GrinnellPlans chooses
+            to conduct an investigation, it will use the investigation procedure
+            described in Appendix A, or another procedure appropriate for the
+            circumstances, in its own discretion.
+        </p>
+        <p>
+            Without limiting the foregoing, we have the right to fully cooperate
+            with any law enforcement authorities or court order requesting or
+            directing us to disclose the identity or other information of anyone
+            posting any materials on or through the Service. YOU WAIVE AND HOLD
+            HARMLESS GRINNELLPLANS FROM ANY CLAIMS RESULTING FROM ANY ACTION
+            TAKEN BY GRINNELLPLANS DURING OR AS A RESULT OF ITS INVESTIGATIONS
+            AND FROM ANY ACTIONS TAKEN AS A CONSEQUENCE OF INVESTIGATIONS BY
+            EITHER GRINNELLPLANS OR LAW ENFORCEMENT AUTHORITIES.
+        </p>
+        <h2>
+            Content Standards
+        </h2>
+        <p>
+            These content standards apply to any and all User Contributions.
+            User Contributions must in their entirety comply with all applicable
+            federal, state, local and international laws and regulations.
+            Without limiting the foregoing, User Contributions must not:
+        </p>
+        <ul>
+            <li>Contain any material which is defamatory, obscene, indecent,
+                abusive, offensive, harassing, violent, hateful, inflammatory or
+                otherwise objectionable;</li>
+            <li>Contain any material which promotes violence or discrimination
+                based on race, sex, gender, religion, nationality, disability,
+                occupation, sexual orientation or age;</li>
+            <li>Infringe any patent, trademark, trade secret, copyright or other
+                intellectual property or other rights of any other person;</li>
+            <li>Violate the legal rights (including the rights of publicity and
+                privacy) of others;</li>
+            <li>Contain any material that could give rise to any civil or
+                criminal liability under applicable laws or regulations or that
+                otherwise may be in conflict with these Terms of Use;</li>
+            <li>Materially misrepresent that they emanate from or are endorsed
+                by us or any other person or entity, if this is not the case.</li>
+        </ul>
+        <p>
+            User Contributions to Secrets must conform to the following
+            standards:
+        </p>
+        <ol>
+            <li>Your post must be a secret.</li>
+            <li>The secret must be your own.</li>
+            <li>The secret may not reference any person or group in any
+                identifiable way.</li>
+        </ol>
+        <h2>
+            Indemnification
+        </h2>
+        <p>
+            You understand and acknowledge that you are responsible for any User
+            Contributions or Content you submit or contribute, and you, not
+            GrinnellPlans, have full responsibility for such content.
+        </p>
+        <p>
+            To the maximum extent allowable by law, we are not responsible, or
+            liable to any third party, for the content or accuracy of any User
+            Contributions posted by you or any other user of the Service.
+            Consequently, GrinnellPlans.com may carry offensive, harmful,
+            inaccurate or otherwise inappropriate material, or in some cases,
+            postings that have been mislabeled or are otherwise deceptive. We
+            expect that you will use caution and common sense and exercise
+            proper judgment when using the Service.
+        </p>
+        <p>
+            With regard to individual Plans, we cannot review material before it
+            is posted on the Service, and cannot ensure removal of objectionable
+            material after it has been posted. Accordingly, we assume no
+            liability for any action or inaction regarding transmissions,
+            communications or content provided by any User or third party. We
+            have no liability or responsibility to anyone for performance or
+            nonperformance of the activities described in this section.
+        </p>
+        <p>
+            With regard to the Secrets section, we review material before it is
+            posted on the Service, and make reasonable efforts to ensure prompt
+            removal of objectionable material if it has been posted. However, we
+            assume no liability for any action or inaction regarding
+            transmissions, communications or content provided by any user or
+            third party. We have no liability or responsibility to anyone for
+            performance or nonperformance of the activities described in this
+            section.
+        </p>
+        <p>
+            If anyone brings a claim against us related to your actions, content
+            or information on GrinnellPlans, you will indemnify and hold us
+            harmless from and against all damages, losses, and expenses of any
+            kind (including reasonable legal fees and costs) related to such
+            claim.
+        </p>
+        <h2>
+            Disclaimer
+        </h2>
+        <p>
+            You understand and agree that the Service is provided to you on an
+            AS IS and AS AVAILABLE basis. To the maximum extent allowable by
+            law, GP disclaims all responsibility and liability for the
+            availability, timeliness, security or reliability of the Service or
+            any other client software. GP also reserves the right to modify,
+            suspend or discontinue the Service with or without notice at any
+            time and without any liability to you.
+        </p>
+        <h2>
+            Governing Law and Jurisdiction
+        </h2>
+        <p>
+            All matters relating to the Service and these Terms of Use and any
+            dispute or claim arising therefrom or related thereto (in each case,
+            including non-contractual disputes or claims), shall be governed by
+            and construed in accordance with the internal laws of the State of
+            Illinois without giving effect to any choice or conflict of law
+            provision or rule (whether of the State of Illinois or any other
+            jurisdiction).
+        </p>
+        <p>
+            All claims, legal proceedings or litigation arising in connection
+            with the Service will be brought solely in the federal or state
+            courts located in Cook County, Illinois, United States, although we
+            retain the right to bring any suit, action or proceeding against you
+            for breach of these Terms of Use in your country of residence or any
+            other relevant country. You waive any and all objections to the
+            exercise of jurisdiction over you by such courts and to venue in
+            such courts.
+        </p>
+        <h2>
+            Changes to the Terms of Use
+        </h2>
+        <p>
+            We may revise and update these Terms of Use from time to time in our
+            sole discretion. All changes are effective immediately when we post
+            them, and apply to all access to and use of the Service thereafter.
+            Notice of changes posted on the homepage is to be considered
+            sufficient notice to you.
+        </p>
+        <h2>
+            Waiver and Severability
+        </h2>
+        <p>
+            No waiver by GrinnellPlans of any term or condition set forth in
+            these Terms of Use shall be deemed a further or continuing waiver of
+            such term or condition or a waiver of any other term or condition.
+            Failure of GrinnellPlans to assert a right or provision under these
+            Terms of Use shall not constitute a waiver of such right or
+            provision.
+        </p>
+        <p>
+            If any provision of these Terms of Use is held by a court or other
+            tribunal of competent jurisdiction to be invalid, illegal or
+            unenforceable for any reason, such provision shall be eliminated or
+            limited to the minimum extent such that the remaining provisions of
+            the Terms of Use will continue in full force and effect.
+        </p>
+        <h2>
+            Entire Agreement
+        </h2>
+        <p>
+            The Terms of Use and referenced appendices constitute the sole and
+            entire agreement between you and GrinnellPlans with respect to the
+            Service and supersede all prior and contemporaneous understandings,
+            agreements, representations and warranties, both written and oral,
+            with respect to the Service.
+        </p>
+        <h2>
+            Your Comments and Concerns
+        </h2>
+        <p>
+            All feedback, comments, requests for technical support and other
+            communications relating to the Service should be directed to:
+            grinnellplans@gmail.com.
+        </p>
+        <p>
+            Thank you for visiting GrinnellPlans. Please govern yourself
+            accordingly.
+        </p>
+        <hr />
+        <h2 class="nocount">
+            Appendix A: Investigation Procedure
+        </h2>
+        <p>
+            The Investigation Procedure described below is a protocol for the
+            investigation of concerns voiced by Users. The Grinnell Plans
+            Administrators have identified these steps as a general roadmap for
+            investigations in order to maximize fair and informed
+            decision-making. But Admin are not bound to use the procedure. An
+            investigation may deviate from it or disregard it in any
+            investigation when circumstances, in Administrators&#39; discretion,
+            warrant. Termination (or other administrative action) based on a
+            violation of the Terms of Service may be effected without an
+            investigation, or with an investigation conducted in some other
+            fashion.
+        </p>
+        <ol>
+            <li>Complaints are emailed to grinnellplans@gmail.com</li>
+            <li>Plans Administrators open an investigation period, and allow
+                individuals to confidentially voice their grievances in case
+                incident is not isolated to an individual or group.</li>
+            <li>Complainants and respondents are contacted and asked to share
+                their side of the story. Our emails and the subsequent responses
+                are archived.</li>
+            <li>At the close of the comment period, a quorum (80%) of Grinnell
+                Administrators discuss grievances, evidence provided, and if
+                needed, contacts a legal representative to advise.</li>
+            <li>Administrators discuss short term, medium term, and long term
+                solutions.</li>
+            <li>At the end of meetings, an email containing the minutes of that
+                meeting are disseminated to the Administrators. Those minutes
+                are confidential, and are not shared with either the complainant
+                or respondent.</li>
+            <li>The same quorum (80%) of Administrators makes a collective
+                decision based off of information that is available that best
+                fits the needs of the community and maintains a safe
+                environment.</li>
+        </ol>
+        <hr />
+        <h2 class="nocount">
+            Appendix B: Digital Millennium Copyright Act.
+        </h2>
+        <p>
+            It is our policy to respond to clear notices of alleged copyright
+            infringement. This page describes the information that should be
+            present in these notices. It is designed to make submitting notices
+            of alleged infringement to GrinnellPlans as straightforward as
+            possible while reducing the number of notices that we receive that
+            are fraudulent or difficult to understand or verify. The form of
+            notice specified below is consistent with the form suggested by the
+            United States Digital Millennium Copyright Act (the text of which
+            can be found at the U.S. Copyright Office Web Site,
+            http://www.copyright.gov) but we will respond to notices of this
+            form from other jurisdictions as well.
+        </p>
+        <p>
+            Regardless of whether we may be liable for such infringement under
+            local country law or United States law, our response to these
+            notices may include removing or disabling access to material claimed
+            to be the subject of infringing activity and/or terminating
+            subscribers. If we remove or disable access in response to such a
+            notice, we will make a good-faith attempt to contact the owner or
+            administrator of the affected site or content so that they may make
+            a counter notification. We may also document notices of alleged
+            infringement on which we act. As with all legal notices, a copy of
+            the notice may be sent to one or more third parties who may make it
+            available to the public.
+        </p>
+        <h3>
+            Infringement Notification:
+        </h3>
+        <p>
+            To file a notice of infringement with us, you must provide a written
+            communication by email to grinnellplans@gmail.com that sets forth
+            the items specified below. Please note that you will be liable for
+            damages (including costs and attorneys&#39; fees) if you materially
+            misrepresent that a product or activity is infringing your
+            copyrights. Indeed, in a recent case (please see
+            http://www.onlinepolicy.org/action/legpolicy/opg_v_diebold/ for more
+            information), a company that sent an infringement notification
+            seeking removal of online materials that were protected by the fair
+            use doctrine was ordered to pay such costs and attorneys fees. The
+            company agreed to pay over $100,000. If you are uncertain whether
+            material available online infringes your copyright, consult your
+            attorney.
+        </p>
+        <p>
+            To expedite our ability to process your request, please use the
+            following format (including section numbers):
+        </p>
+        <ol>
+            <li>Identify in sufficient detail the copyrighted work that you
+                believe has been infringed upon. This post must include
+                identification of the specific posts, as opposed to entire
+                sites. Posts must be referenced by the permalink of the post.
+                For example, &ldquo;The copyrighted work at issue is the text
+                that appears on http://johndoe.com/test/2006_01_01.html#2106.</li>
+            <li>Identify the material that you claim is infringing the
+                copyrighted work listed in item #1 above.<br />
+                YOU MUST IDENTIFY EACH POST BY PERMALINK OR DATE THAT ALLEGEDLY
+                CONTAINS THE INFRINGING MATERIAL. The permalink for a post is
+                usually found by clicking on the timestamp of the post. For
+                example, &ldquo;The blog where my copyrighted work is published
+                on is
+                http://copyright.grinnellplans.com/archives/2006_01_02_example.html.&rdquo;</li>
+            <li>Provide information reasonably sufficient to permit
+                GrinnellPlans to contact you (email address is preferred).</li>
+            <li>Include the following statement: &quot;I have a good faith
+                belief that use of the copyrighted material described above on
+                the allegedly infringing web pages is not authorized by the
+                copyright owner, its agent, or the law.&quot;.</li>
+            <li>Include the following statement: &quot;I swear, under penalty of
+                perjury, that the information in the notification is accurate
+                and that I am the copyright owner or am authorized to act on
+                behalf of the owner of an exclusive right that is allegedly
+                infringed.&quot;</li>
+            <li>Sign the document. Electronic signatures are sufficient.</li>
+        </ol>
+        <h3>
+            Counter Notification
+        </h3>
+        <p>
+            The administrator of an affected site or the provider of affected
+            content may make a counter notification pursuant to sections
+            512(g)(2) and (3) of the Digital Millennium Copyright Act. When we
+            receive a counter notification, we may reinstate the material in
+            question.
+        </p>
+        <p>
+            To file a counter notification with us, you must provide an email to
+            grinnellplans@gmail.com that sets forth the items specified below.
+            Please note that you will be liable for damages (including costs and
+            attorneys&#39; fees) if you materially misrepresent that a product
+            or activity is not infringing the copyrights of others. Accordingly,
+            if you are not sure whether certain material infringes the
+            copyrights of others, consult your attorney.
+        </p>
+        <p>
+            To expedite our ability to process your counter notification, please
+            use the following format (including section numbers):
+        </p>
+        <ol>
+            <li>Identify the specific URLs or other unique identifying
+                information of material that GrinnellPlans has removed or to
+                which GrinnellPlans has disabled access.</li>
+            <li>Provide your name, address, telephone number, email address, and
+                a statement that you consent to the jurisdiction of Federal
+                District Court for the judicial district in which your address
+                is located, and that you will accept service of process from the
+                person who provided notification under subsection (c)(1)(C) or
+                an agent of such person.</li>
+            <li>Include the following statement: &quot;I swear, under penalty of
+                perjury, that I have a good faith belief that each search
+                result, message, or other item of content identified above was
+                removed or disabled as a result of a mistake or
+                misidentification of the material to be removed or disabled, or
+                that the material identified by the complainant has been removed
+                or disabled at the URL identified and will no longer be
+                shown.&quot;</li>
+            <li>Sign the paper. Electronic signatures are sufficient.</li>
+        </ol>
+        <p>
+            GrinnellPlans will, in appropriate circumstances, terminate repeat
+            infringers. If you believe that an account holder or subscriber is a
+            repeat infringer, please follow the instructions above to contact
+            GrinnellPlans&#39;s DMCA agent and provide information sufficient
+            for us to verify that the account holder or subscriber is a repeat
+            infringer.
+        </p>
+    </body>
 </html>

--- a/views/templates/tableless/PlansPage.tpl.php
+++ b/views/templates/tableless/PlansPage.tpl.php
@@ -4,7 +4,7 @@
 
 <head>
 <title><?php echo $this->page_title ?></title>
-
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <?php foreach($this->stylesheets as $css): ?>
 	<link rel="stylesheet" type="text/css" href="<?php echo $css; ?>">
 <?php


### PR DESCRIPTION
I added the viewport tag to the tableless interface, but not the legacy interface with tables which was the [general consensus](https://github.com/grinnellplans/grinnellplans-php/issues/179#issuecomment-1688952067) on #179.

I also added it to the [login screen](https://www.grinnellplans.com/), [FAQ page](https://www.grinnellplans.com/documents/faq.html), [TOS page](https://www.grinnellplans.com/tos/), [donations page](https://grinnellplans.com/donations/donations.php) (seems to not be working right?), and [stylesheet reset page](https://www.grinnellplans.com/reset.php) (I didn't know about that one!).

On `index.php`, I also removed a few lines of commented-out CSS and added in a single ruleset to [make sure the plans logo is responsive](https://github.com/grinnellplans/grinnellplans-php/issues/179#issuecomment-1690266031). It was **_extremely_** tempting to cleanup HTML markup and line indents, but I managed to resist.

I didn't try very hard, but I didn't see any obvious instructions for testing this locally, so I haven't. I'm hoping these changes are minimal enough and only targeted at markup so the chances of any real breakage seem really low.

If it would be helpful, I'd be happy to draft some language for mods to post on the home page (or just [css]?). Just ask :)

What else can I do to help get this out?